### PR TITLE
Bug flood duration

### DIFF
--- a/Database/Models/EligibilityCheckDto.cs
+++ b/Database/Models/EligibilityCheckDto.cs
@@ -10,6 +10,7 @@ public record EligibilityCheckDto
     public double Northing { get; init; }
     public string? LocationDesc { get; init; }
     public DateTimeOffset? ImpactStart { get; init; }
+    public Guid? DurationKnownId { get; init; }
     public int? ImpactDuration { get; init; } // In hours
     public bool OnGoing { get; init; }
     public bool? Uninhabitable { get; init; }

--- a/Database/Repositories/CommonRepository.cs
+++ b/Database/Repositories/CommonRepository.cs
@@ -25,6 +25,14 @@ public class CommonRepository(PublicDbContext context, BoundariesDbContext bound
             .ConfigureAwait(false);
     }
 
+    public async Task<FloodProblem?> GetFloodProblemByCategory(string category, Guid id, CancellationToken ct)
+    {
+        return await context.FloodProblems
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Category == category && o.Id == id, ct)
+            .ConfigureAwait(false);
+    }
+
     public async Task<IList<FloodProblem>> GetFloodProblemsByCategory(string category, CancellationToken ct)
     {
         return await context.FloodProblems

--- a/Database/Repositories/FloodReportRepository.cs
+++ b/Database/Repositories/FloodReportRepository.cs
@@ -5,6 +5,7 @@ using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Globalization;
 
 namespace FloodOnlineReportingTool.Database.Repositories;
 
@@ -124,6 +125,8 @@ public class FloodReportRepository(
         var eligibilityCheckId = Guid.CreateVersion7();
         var now = DateTimeOffset.UtcNow;
 
+        var impactDuration = await GetImpactDurationHours(dto.OnGoing, dto.DurationKnownId, dto.ImpactDuration,  ct).ConfigureAwait(false);
+        
         var floodReport = new FloodReport
         {
             Reference = CreateReference(),
@@ -142,7 +145,7 @@ public class FloodReportRepository(
                 Northing = dto.Northing,
                 LocationDesc = dto.LocationDesc,
                 ImpactStart = dto.ImpactStart,
-                ImpactDuration = dto.ImpactDuration ?? 0,
+                ImpactDuration = impactDuration,
                 OnGoing = dto.OnGoing,
                 Uninhabitable = dto.Uninhabitable == true,
                 VulnerablePeopleId = dto.VulnerablePeopleId,
@@ -181,5 +184,48 @@ public class FloodReportRepository(
     public bool HasInvestigationStarted(Guid status)
     {
         return status == RecordStatusIds.ActionNeeded;
+    }
+
+    /// <summary>
+    ///     <para>Calculates the impact duration hours.</para>
+    ///     <para>If the flood is still happening this will be zero.</para>
+    ///     <para>If the flood duration is known, it will return the hours provided by the user.</para>
+    ///     <para>Otherwise, it will try to get the duration hours from the flood problem in the database.</para>
+    /// </summary>
+    private async Task<int> GetImpactDurationHours(bool isOngoing, Guid? durationKnownId, int? impactDurationHours,  CancellationToken ct)
+    {
+        // The flood is still happening, so there is no duration
+        if (isOngoing)
+        {
+            logger.LogInformation("Flood is ongoing, so impact duration is not known yet.");
+            return 0;
+        }
+
+        if (durationKnownId == null)
+        {
+            logger.LogError("Impact duration is not known, and no duration known Id was provided.");
+            return 0;
+        }
+
+        // The user has indicated that the flood duration is known
+        if (durationKnownId == FloodProblemIds.DurationKnown)
+        {
+            logger.LogInformation("Impact duration is known, using provided impact duration hours.");
+            return impactDurationHours ?? 0;
+        }
+
+        // Get the duration from the flood problem
+        var floodProblem = await context.FloodProblems
+            .FindAsync([durationKnownId], ct)
+            .ConfigureAwait(false);
+
+        if (int.TryParse(floodProblem?.TypeName, CultureInfo.InvariantCulture, out var durationHours))
+        {
+            logger.LogInformation("Impact duration is {Duration} hours.", durationHours);
+            return durationHours;
+        }
+
+        logger.LogError("Could not parse impact duration from flood problem type name");
+        return 0;
     }
 }

--- a/Database/Repositories/ICommonRepository.cs
+++ b/Database/Repositories/ICommonRepository.cs
@@ -6,6 +6,7 @@ public interface ICommonRepository
 {
     Task<FloodImpact?> GetFloodImpact(Guid id, CancellationToken ct);
     Task<IList<FloodImpact>> GetFloodImpactsByCategory(string category, CancellationToken ct);
+    Task<FloodProblem?> GetFloodProblemByCategory(string category, Guid id, CancellationToken ct);
     Task<IList<FloodProblem>> GetFloodProblemsByCategory(string category, CancellationToken ct);
     Task<IList<FloodProblem>> GetFloodProblemsByCategories(string[] categories, CancellationToken ct);
     Task<IList<FloodMitigation>> GetFloodMitigationsByCategory(string category, CancellationToken ct);

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/FloodDuration.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/FloodDuration.razor.cs
@@ -69,16 +69,19 @@ public partial class FloodDuration(
 
             _floodStart = eligibilityCheck.ImpactStart;
             _isFloodOngoing = eligibilityCheck.OnGoing;
-            if (eligibilityCheck.ImpactDuration.HasValue)
-            {
-                var days = eligibilityCheck.ImpactDuration.Value / 24;
-                var hours = eligibilityCheck.ImpactDuration.Value % 24;
 
-                Model.DurationKnownId = FloodProblemIds.DurationKnown;
-                Model.DurationDaysNumber = days;
-                Model.DurationDaysText = days.ToString(CultureInfo.CurrentCulture);
-                Model.DurationHoursNumber = hours;
-                Model.DurationHoursText = hours.ToString(CultureInfo.CurrentCulture);
+            Model.DurationKnownId = eligibilityCheck.DurationKnownId;
+            if (Model.DurationKnownId == FloodProblemIds.DurationKnown)
+            {
+                if (eligibilityCheck.ImpactDuration != null)
+                {
+                    var days = eligibilityCheck.ImpactDuration.Value / 24;
+                    var hours = eligibilityCheck.ImpactDuration.Value % 24;
+                    Model.DurationDaysNumber = days;
+                    Model.DurationDaysText = days.ToString(CultureInfo.CurrentCulture);
+                    Model.DurationHoursNumber = hours;
+                    Model.DurationHoursText = hours.ToString(CultureInfo.CurrentCulture);
+                }
             }
 
             _durationOptions = await CreateDurationOptions();
@@ -107,16 +110,13 @@ public partial class FloodDuration(
 
     private async Task OnValidSubmit()
     {
-        int? impactDuration = null;
-        if (Model.DurationKnownId == FloodProblemIds.DurationKnown)
-        {
-            impactDuration = (Model.DurationDaysNumber ?? 0) * 24 + (Model.DurationHoursNumber ?? 0);
-        }
-
         var eligibilityCheck = await GetEligibilityCheck();
         var updated = eligibilityCheck with
         {
-            ImpactDuration = impactDuration,
+            DurationKnownId = Model.DurationKnownId,
+            ImpactDuration = Model.DurationKnownId == FloodProblemIds.DurationKnown
+                ? (Model.DurationDaysNumber ?? 0) * 24 + (Model.DurationHoursNumber ?? 0)
+                : null,
         };
 
         await protectedSessionStorage.SetAsync(SessionConstants.EligibilityCheck, updated);

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Summary.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Summary.razor
@@ -43,12 +43,19 @@
                     Areas flooded
                 </dt>
                 <dd class="govuk-summary-list__value">
-                    <ul class="govuk-list">
-                        @foreach (var label in Model.FloodedAreas)
-                        {
-                            <li>@label</li>
-                        }
-                    </ul>
+                    @if (Model.FloodedAreas.Count == 0)
+                    {
+                        <span>Unknown</span>
+                    }
+                    else
+                    {
+                        <ul class="govuk-list">
+                            @foreach (var label in Model.FloodedAreas)
+                            {
+                                <li>@label</li>
+                            }
+                        </ul>
+                    }
                 </dd>
                 <dd class="govuk-summary-list__actions">
                     <a draggable="false" data-prevent-double-click="true" href="@(FloodReportCreatePages.FloodAreas.Url)?fromSummary=true" class="govuk-link">Change<span class="govuk-visually-hidden"> which areas of the property were flooded</span></a>
@@ -61,7 +68,7 @@
                 <dd class="govuk-summary-list__value">
                     @if(Model.IsUninhabitable == null)
                     {
-                        <>Unknown</>
+                        <span>Unknown</span>
                     }
                     else
                     {
@@ -95,7 +102,7 @@
                 <dd class="govuk-summary-list__value">
                     @if (Model.IsOnGoing == null)
                     {
-                        <>Unknown</>
+                        <span>Unknown</span>
                     }
                     else
                     {
@@ -113,18 +120,10 @@
                         Flooding lasted
                     </dt>
                     <dd class="govuk-summary-list__value">
-                        @if (Model.FloodDurationHours == null)
-                        {
-                            <>Unknown</>
-                        }
-                        else
-                        {
-                            var duration = TimeSpan.FromHours(Model.FloodDurationHours.Value);
-                            @duration.GdsReadable()
-                        }
+                        @(Model.FloodingLasted ?? "Unknown")
                     </dd>
                     <dd class="govuk-summary-list__actions">
-                            <a draggable="false" data-prevent-double-click="true" href="@(FloodReportCreatePages.FloodDuration.Url)?fromSummary=true" class="govuk-link">Change<span class="govuk-visually-hidden"> how long the flooding lasted</span></a>
+                        <a draggable="false" data-prevent-double-click="true" href="@(FloodReportCreatePages.FloodDuration.Url)?fromSummary=true" class="govuk-link">Change<span class="govuk-visually-hidden"> how long the flooding lasted</span></a>
                     </dd>
                 </div>
             }
@@ -144,12 +143,19 @@
                     Flood source
                 </dt>
                 <dd class="govuk-summary-list__value">
-                    <ul class="govuk-list">
-                        @foreach (var label in Model.FloodSources)
-                        {
-                            <li>@label</li>
-                        }
-                    </ul>
+                    @if (Model.FloodSources.Count == 0)
+                    {
+                        <span>Unknown</span>
+                    }
+                    else
+                    {
+                        <ul class="govuk-list">
+                            @foreach (var label in Model.FloodSources)
+                            {
+                                <li>@label</li>
+                            }
+                        </ul>
+                    }
                 </dd>
                 <dd class="govuk-summary-list__actions">
                     <a draggable="false" data-prevent-double-click="true" href="@(FloodReportCreatePages.FloodSource.Url)?fromSummary=true" class="govuk-link">Change<span class="govuk-visually-hidden"> the source of the flooding</span></a>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Summary.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Summary.razor.cs
@@ -70,9 +70,26 @@ public partial class Summary(
             Model.IsUninhabitable = eligibilityCheck.Uninhabitable;
             Model.StartDate = eligibilityCheck.ImpactStart;
             Model.IsOnGoing = eligibilityCheck.OnGoing;
-            Model.FloodDurationHours = eligibilityCheck.ImpactDuration;
+            Model.FloodDurationKnownId = eligibilityCheck.DurationKnownId;
             Model.VulnerablePeopleId = eligibilityCheck.VulnerablePeopleId;
             Model.NumberOfVulnerablePeople = eligibilityCheck.VulnerableCount;
+
+            // Build the flood lasted for message
+            Model.FloodingLasted = null;
+            var durationId = eligibilityCheck.DurationKnownId;
+            if (!eligibilityCheck.OnGoing && durationId != null)
+            {
+                if (durationId.Value == FloodProblemIds.DurationKnown && eligibilityCheck.ImpactDuration != null)
+                {
+                    var duration = TimeSpan.FromHours(eligibilityCheck.ImpactDuration.Value);
+                    Model.FloodingLasted = duration.GdsReadable();
+                }
+                else
+                {
+                    var floodDuration = await commonRepository.GetFloodProblemByCategory(FloodProblemCategory.Duration, durationId.Value, _cts.Token);
+                    Model.FloodingLasted = floodDuration?.TypeDescription;
+                }
+            }
 
             _isLoading = false;
             StateHasChanged();

--- a/FloodOnlineReportingTool.Public/Models/FloodReport/Create/Summary.cs
+++ b/FloodOnlineReportingTool.Public/Models/FloodReport/Create/Summary.cs
@@ -16,7 +16,9 @@ public class Summary
 
     public bool? IsOnGoing { get; set; }
 
-    public int? FloodDurationHours { get; set; }
+    public Guid? FloodDurationKnownId { get; set; }
+
+    public string? FloodingLasted { get; set; }
 
     public Guid? VulnerablePeopleId { get; set; }
 

--- a/FloodOnlineReportingTool.Public/Validators/Create/SummaryValidator.cs
+++ b/FloodOnlineReportingTool.Public/Validators/Create/SummaryValidator.cs
@@ -36,10 +36,17 @@ public class SummaryValidator : AbstractValidator<Summary>
             .NotEmpty()
             .WithMessage("Flooding on-going is empty.");
 
-        RuleFor(o => o.FloodDurationHours)
-            .NotEmpty()
-            .WithMessage("Flood duration is empty.")
-            .When(o => o.IsOnGoing == false);
+        When(o => o.IsOnGoing == false, () =>
+        {
+            RuleFor(o => o.FloodDurationKnownId)
+                .NotEmpty()
+                .WithMessage("Flood duration is empty.");
+
+            RuleFor(o => o.FloodingLasted)
+                .NotEmpty()
+                .WithMessage("Flood lasted is empty.")
+                .When(o => o.FloodDurationKnownId != null);
+        });
 
         RuleFor(o => o.VulnerablePeopleId)
             .NotEmpty()


### PR DESCRIPTION
- Resolves #23 
- Fix - Remember the flood duration option the user selects
- Fix - Summary screen shows the flood duration option the user selected, when the flood has ended
- New - Common repository method to get a single flood problem by category and ID
- New - Calculate the impact duration in hours based on if the flood is still happening, if the user knew the flood duration, or the default hours configured in the database