### PR TITLE
PR2 - Add repository interfaces and DTOs for contact management

### DIFF
--- a/Database/Models/Contact/Subscribe/SubscribeCreateOrUpdateResult.cs
+++ b/Database/Models/Contact/Subscribe/SubscribeCreateOrUpdateResult.cs
@@ -1,0 +1,8 @@
+﻿namespace FloodOnlineReportingTool.Database.Models.Contact.Subscribe;
+
+public record SubscribeCreateOrUpdateResult(bool IsSuccess, SubscribeRecord? SubscriptionRecord, ICollection<string> Errors)
+{
+    internal static SubscribeCreateOrUpdateResult Success(SubscribeRecord SubscriptionRecord) => new(IsSuccess: true, SubscriptionRecord, []);
+
+    internal static SubscribeCreateOrUpdateResult Failure(ICollection<string> errors) => new(IsSuccess: false, SubscriptionRecord: null, errors);
+}

--- a/Database/Models/Contact/Subscribe/SubscribeDeleteResult.cs
+++ b/Database/Models/Contact/Subscribe/SubscribeDeleteResult.cs
@@ -1,0 +1,8 @@
+﻿namespace FloodOnlineReportingTool.Database.Models.Contact.Subscribe;
+
+public record SubscribeDeleteResult(bool IsSuccess, ICollection<string> Errors)
+{
+    internal static SubscribeDeleteResult Success() => new(IsSuccess: true, []);
+
+    internal static SubscribeDeleteResult Failure(ICollection<string> errors) => new(IsSuccess: false, errors);
+}

--- a/Database/Repositories/IContactRecordRepository.cs
+++ b/Database/Repositories/IContactRecordRepository.cs
@@ -1,5 +1,6 @@
 ﻿using FloodOnlineReportingTool.Contracts.Shared;
 using FloodOnlineReportingTool.Database.Models.Contact;
+using FloodOnlineReportingTool.Database.Models.Contact.Subscribe;
 
 namespace FloodOnlineReportingTool.Database.Repositories;
 
@@ -11,7 +12,13 @@ public interface IContactRecordRepository
     Task<ContactRecord?> GetContactById(Guid contactRecordId, CancellationToken ct);
 
     /// <summary>
-    /// Get all contact records associated with a flood report
+    /// Get the report owner contact records associated with a flood report
+    /// </summary>
+    /// <returns></returns>
+    Task<SubscribeRecord?> GetReportOwnerContactByReport(Guid floodReportId, CancellationToken ct);
+
+    /// <summary>
+    /// Get all other contact records associated with a flood report
     /// </summary>
     Task<IReadOnlyCollection<ContactRecord>> GetContactsByReport(Guid floodReportId, CancellationToken ct);
 
@@ -21,6 +28,11 @@ public interface IContactRecordRepository
     /// <remarks>This system is fully responsible for all contact communication. No notifications are sent out at this point.</remarks>
     Task<ContactRecordCreateOrUpdateResult> CreateForReport(Guid floodReportId, ContactRecordDto dto, CancellationToken ct);
 
+    /// <summary>
+    /// Adds the provided flood report to an existing contact record
+    /// </summary>
+    /// <returns></returns>
+    Task<ContactRecordCreateOrUpdateResult> LinkContactByReport(Guid floodReportId, Guid contactRecordId, CancellationToken ct);
     /// <summary>
     /// Update the contact record, going via the flood report
     /// </summary>
@@ -34,6 +46,42 @@ public interface IContactRecordRepository
     Task<ContactRecordDeleteResult> DeleteById(Guid contactRecordId, ContactRecordType contactType, CancellationToken ct);
 
     /// <summary>
+    /// Creates a contact subscription record
+    /// </summary>
+    /// <returns>This record will be linked to a contact record once completed. Unlinked records will be deleted after retention date.</returns>
+    Task<SubscribeCreateOrUpdateResult> CreateSubscriptionRecord(Guid contactRecordId, ContactRecordDto dto, string? userEmail, bool userPresent, CancellationToken ct);
+
+    /// <summary>
+    /// Returns a current subscription record by its ID
+    /// </summary>
+    /// <returns></returns>
+    Task<SubscribeRecord?> GetSubscriptionRecordById(Guid subscriptionId, CancellationToken ct);
+
+    /// <summary>
+    /// Verifies a contact subscription record
+    /// </summary>
+    /// <returns></returns>
+    Task<bool> VerifySubscriptionRecord(Guid subscriptionId, int verificationCode, CancellationToken ct);
+
+    /// <summary>
+    /// This updates the verification code and expiry on a subscription record
+    /// </summary>
+    /// <returns></returns>
+    Task<SubscribeCreateOrUpdateResult> UpdateVerificationCode(SubscribeRecord subscriptionRecord, bool userPresent, CancellationToken ct);
+
+    /// <summary>
+    /// Updates a subscription record
+    /// </summary>
+    /// <returns></returns>
+    Task<SubscribeCreateOrUpdateResult> UpdateSubscriptionRecord(SubscribeRecord subscriptionRecord, CancellationToken ct);
+
+    /// <summary>
+    /// Deletes a subscription record by its ID
+    /// </summary>
+    /// <returns></returns>
+    Task<SubscribeDeleteResult> DeleteSubscriptionById(Guid subscriptionId, CancellationToken ct);
+
+    /// <summary>
     /// Count the number of unused contact record types, going via the flood report
     /// </summary>
     Task<int> CountUnusedRecordTypes(Guid floodReportId, CancellationToken ct);
@@ -45,5 +93,5 @@ public interface IContactRecordRepository
 
     Task<bool> ContactRecordExists(Guid contactRecordId, CancellationToken ct = default);
 
-    Task<bool> ContactRecordExistsForUser(Guid userId, CancellationToken ct = default);
+    Task<Guid?> ContactRecordExistsForUser(Guid userId, CancellationToken ct = default);
 }

--- a/Database/Repositories/IFloodReportRepository.cs
+++ b/Database/Repositories/IFloodReportRepository.cs
@@ -21,6 +21,12 @@ public interface IFloodReportRepository
     Task<IReadOnlyCollection<FloodReport>> AllReportedByContact(Guid contactUserId, CancellationToken ct);
 
     /// <summary>
+    /// This enables contact subscriptions for the flood report
+    /// </summary>
+    /// <returns></returns>
+    Task<FloodReportCreateOrUpdateResult> EnableContactSubscriptionsForReport(Guid floodReportId, CancellationToken ct);
+
+    /// <summary>
     /// Flood report by ID.
     /// </summary>
     /// <returns></returns>


### PR DESCRIPTION
This pull request introduces new models and extends repository interfaces to support contact subscription functionality in the system. It adds result record types for subscription creation, update, and deletion, and updates the `IContactRecordRepository` and `IFloodReportRepository` interfaces to provide methods for managing contact subscriptions, including creation, verification, updating, and deletion.

**Contact Subscription Models:**

- Added `SubscribeCreateOrUpdateResult` and `SubscribeDeleteResult` record types to represent the outcomes of subscription creation/update and deletion operations, including success flags and error messages. [[1]](diffhunk://#diff-f6c6e25c2e0036b84d79df1b23d1bca611f311c9a5d2cea9c424d5cae0c31b52R1-R8) [[2]](diffhunk://#diff-5c1cd5fa0bd9a05e26df7c887814f1c007e81db3a24bd995caa4ddd5789d87b1R1-R8)

**Repository Interface Extensions:**

_Contact Record Repository (`IContactRecordRepository`):_

- Added methods for contact subscription management: creating, retrieving, verifying, updating, and deleting subscription records, as well as updating verification codes.
- Added `GetReportOwnerContactByReport` to retrieve the report owner’s contact record and clarified the distinction between owner and other contacts in method documentation.
- Added `LinkContactByReport` to associate an existing contact with a flood report.
- Updated `ContactRecordExistsForUser` to return the contact record ID if it exists, rather than just a boolean.
- Included necessary namespace import for new subscription models.

_Flood Report Repository (`IFloodReportRepository`):_

- Added `EnableContactSubscriptionsForReport` to allow enabling contact subscriptions for a given flood report.