### PR TITLE
PR4 - Add email notification interfaces for contacts

### DIFF
--- a/FloodOnlineReportingTool.Public/Options/GovNotifyTemplates.cs
+++ b/FloodOnlineReportingTool.Public/Options/GovNotifyTemplates.cs
@@ -10,16 +10,24 @@ public class GovNotifyTemplates
 
     /// <summary>
     ///     <para>GovNotify template Id under ? > ?. Name: ?.</para>
+    ///     <para>This template is used when a user submits a report and summarises their report and tells them how they can make changes</para>
+    /// </summary>  
+    public required string ReportSubmitted { get; init; }
+
+    /// <summary>
+    ///     <para>GovNotify template Id under ? > ?. Name: ?.</para>
     ///     <para>This template is used whenever an email address is added or changed.</para>
-    ///     <para>The reciepient is able to verify the email if not added in error and will be given the rights set out in the notification.</para>
+    ///     <para>The recipient is able to verify the email if not added in error and will be given the rights set out in the notification.</para>
     /// </summary>
     public required string VerifyEmailAddress { get; init; }
 
     /// <summary>
     ///     <para>GovNotify template Id under ? > ?. Name: ?.</para>
-    ///     <para>This template is used to confirm to the contact that their changes have been saved.</para>
+    ///     <para>This template is used whenever an email address is added or changed and the user is not present.</para>
+    ///     <para>The recipient is able to verify the email if not added in error and will be given the rights set out in the notification.</para>
     /// </summary>
-    public required string ConfirmContactUpdated { get; init; }
+    public required string VerifyEmailLinkAddress { get; init; }
+
 
     /// <summary>
     ///     <para>GovNotify template Id under ? > ?. Name: ?.</para>

--- a/FloodOnlineReportingTool.Public/Services/IGovNotifyEmailSender.cs
+++ b/FloodOnlineReportingTool.Public/Services/IGovNotifyEmailSender.cs
@@ -2,11 +2,14 @@
 
 public interface IGovNotifyEmailSender
 {
+    // Report submitted notifications
+    Task<string> SendReportSubmittedNotification(bool isRecordOwner, bool canEdit, string recordReference, string contactType, string contactDisplayName, string contactEmail, string contactPhone, string locationDescription, double easting, double northing, DateTimeOffset reportDate);
+
+    // Account notifications
+    Task<string> SendEmailVerificationNotification(string contactEmail, string contactDisplayName, int? verificationCode, DateTimeOffset verificationExpiryUtc);
+    Task<string> SendEmailVerificationLinkNotification(string contactEmail, string contactDisplayName, int? verificationCode, DateTimeOffset verificationExpiryUtc);
+
     // Contact notifications
-    // The create contact is a special case where we verify the contact email but also notify them of the particulars of the record and how it can be edited.
-    Task<string> SendEmailVerificationNotification(string contactType, bool isPrimary, bool temporaryAccessOnly, string contactEmail, string contactPhone, string contactDisplayName, string recordReference, string locationDescription, double easting, double northing, DateTimeOffset reportDate);
-    // Regular contact notifications
-    Task<string> SendContactUpdatedNotification(string contactType, string contactEmail, string contactPhone, string contactDisplayName, string recordReference);
     Task<string> SendContactDeletedNotification(string contactType, string contactEmail, string contactDisplayName, string recordReference);
 
     // Test notifications


### PR DESCRIPTION
This pull request updates the GovNotify email notification system to support new and more specific notification templates, and refactors the related service interface for clarity and maintainability. The changes focus on introducing a dedicated report submission notification, splitting out email verification methods, and improving naming and documentation.

**Key changes:**

### New notification templates and fields

* Added a new `ReportSubmitted` template property to `GovNotifyTemplates` for notifying users when they submit a report, summarizing their submission and explaining how to make changes.
* Replaced the `ConfirmContactUpdated` property with a new `VerifyEmailLinkAddress` property, clarifying its purpose and documentation.

### Service interface refactoring

* Updated `IGovNotifyEmailSender` to add a `SendReportSubmittedNotification` method for sending report submission confirmations.
* Split email verification into two distinct methods: `SendEmailVerificationNotification` and `SendEmailVerificationLinkNotification`, improving clarity for different verification scenarios.
* Removed overloaded and ambiguous contact notification methods (`SendEmailVerificationNotification` with contact details and `SendContactUpdatedNotification`), simplifying the interface.

### Documentation improvements

* Improved XML documentation for notification template properties, correcting typos and clarifying the intended use of each template.