### PR TITLE
PR9 - Add contact creation form

### DIFF
--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor
@@ -37,7 +37,7 @@
 
             <div class="govuk-button-group">
                 <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">Save</button>
-                <a draggable="false" data-prevent-double-click="true" class="govuk-link govuk-link--no-visited-state" href="@ContactPages.Home.Url">Cancel</a>
+                <a draggable="false" data-prevent-double-click="true" class="govuk-link govuk-link--no-visited-state" href="@ContactPages.Summary.Url">Cancel</a>
             </div>
         </EditForm>
     }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor.cs
@@ -15,10 +15,8 @@ public partial class Create(
     ILogger<Create> logger,
     NavigationManager navigationManager,
     IContactRecordRepository contactRepository,
-    IFloodReportRepository floodReportRepository,
     SessionStateService scopedSessionStorage,
-    IGovNotifyEmailSender govNotifyEmailSender,
-    IGdsJsInterop gdsJs
+    ICurrentUserService currentUserService
 ) : IPageOrder, IAsyncDisposable
 {
     // Page order properties
@@ -26,22 +24,23 @@ public partial class Create(
     public IReadOnlyCollection<GdsBreadcrumb> Breadcrumbs { get; set; } = [
         GeneralPages.Home.ToGdsBreadcrumb(),
         FloodReportPages.Overview.ToGdsBreadcrumb(),
-        ContactPages.Home.ToGdsBreadcrumb(),
+        ContactPages.Summary.ToGdsBreadcrumb(),
     ];
-
-    [CascadingParameter]
-    public EditContext EditContext { get; set; } = default!;
 
     [CascadingParameter]
     public Task<AuthenticationState>? AuthenticationState { get; set; }
 
-    public IReadOnlyCollection<GdsOptionItem<ContactRecordType>> ContactTypes = [];
+    [CascadingParameter]
+    public EditContext EditContext { get; set; } = default!;
+    private EditContext _editContext = default!;
 
+    public IReadOnlyCollection<GdsOptionItem<ContactRecordType>> ContactTypes = [];
     private ContactModel? _contactModel;
+
     private bool _isLoading = true;
     private Guid _floodReportId;
+    private Guid _userId = Guid.Empty;
     private Database.Models.Flood.FloodReport? _floodReport;
-    private EditContext _editContext = default!;
     private ValidationMessageStore _messageStore = default!;
     private readonly CancellationTokenSource _cts = new();
 
@@ -78,22 +77,8 @@ public partial class Create(
             var authState = await AuthenticationState;
             var user = authState.User;
 
-            if (user.Identity?.IsAuthenticated ?? false)
-            {
-                // Populate model with known user info
-                _contactModel.ContactName = string.IsNullOrWhiteSpace(_contactModel.ContactName) ? user.Identity.Name : _contactModel.ContactName;
-                var oidClaim = user.FindFirst("oid")?.Value;
-                _contactModel.ContactUserId = Guid.TryParse(oidClaim, out var parsedOid) ? parsedOid : null;
-
-                // Example: populate email if available
-                var email = user.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value;
-                if (!string.IsNullOrWhiteSpace(email))
-                {
-                    _contactModel.EmailAddress = string.IsNullOrWhiteSpace(_contactModel.EmailAddress) ? email : _contactModel.EmailAddress;
-                }
-
-            }
-
+            var oidClaim = user.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value;
+            _userId = Guid.TryParse(oidClaim, out var parsedOid) ? parsedOid : Guid.Empty;
         }
     }
 
@@ -123,7 +108,7 @@ public partial class Create(
 
             _isLoading = false;
             StateHasChanged();
-            await gdsJs.InitGds(_cts.Token);
+            
         }
     }
 
@@ -144,53 +129,54 @@ public partial class Create(
         logger.LogDebug("Creating contact information");
         try
         {
-            _floodReport = await floodReportRepository.GetById(_floodReportId, _cts.Token);
-            if (_contactModel == null || _floodReport == null)
+            if (_contactModel == null)
             {
                 logger.LogError("There was a problem creating contact information");
                 return;
             }
-            var userId = await AuthenticationState.IdentityUserId();
-            ContactRecordDto dto = new()
+
+            // Generate a contact record
+            _floodReportId = await scopedSessionStorage.GetFloodReportId();
+            ContactRecordDto dto = new ContactRecordDto
             {
-                UserId = userId,
+                UserId = _userId == Guid.Empty ? null: _userId,
                 ContactType = _contactModel.ContactType!.Value,
                 ContactName = _contactModel.ContactName!,
                 EmailAddress = _contactModel.EmailAddress!,
-                IsEmailVerified = false,
                 PhoneNumber = _contactModel.PhoneNumber,
+                IsRecordOwner = false
             };
-            var createResult = await contactRepository.CreateForReport(_floodReportId, dto, _cts.Token);
 
-            // Success - send confirmation email
-            // TODO - enable this once notification is available
-            //var sentNotification = await govNotifyEmailSender.SendEmailVerificationNotification(
-            //    _contactModel.ContactType!.Value.ToString(),
-            //    _contactModel.PrimaryContactRecord,
-            //    userId == null ? true : false,
-            //    _contactModel.EmailAddress!,
-            //    _contactModel.PhoneNumber!,
-            //    _contactModel.ContactName!,
-            //    _floodReport.Reference,
-            //    _floodReport.EligibilityCheck!.LocationDesc ?? "",
-            //    _floodReport.EligibilityCheck!.Easting,
-            //    _floodReport.EligibilityCheck!.Northing,
-            //    _floodReport.CreatedUtc
-            //    );
-
-            if (!createResult.IsSuccess)
+            var contactRecord = await contactRepository.GetContactsByReport(_floodReportId, _cts.Token);
+            Guid contactRecordId;
+            if (contactRecord.Count == 0)
             {
-                var field = _editContext.Field(nameof(_contactModel.ContactType));
-                foreach (var error in createResult.Errors)
+                var newRecord = await contactRepository.CreateForReport(_floodReportId, dto, _cts.Token);
+                if (!newRecord.IsSuccess)
                 {
-                    _messageStore.Add(field, error);
+                    return;
                 }
-                _editContext.NotifyValidationStateChanged();
+                contactRecordId = newRecord.ContactRecord!.Id;
+            }
+            else
+            {
+                contactRecordId = contactRecord.First().Id;
+            }
+            var generatedSubscribeRecord = await contactRepository.CreateSubscriptionRecord(contactRecordId, dto, currentUserService.Email, false, _cts.Token);
+
+           if (generatedSubscribeRecord == null || !generatedSubscribeRecord.IsSuccess)
+            {
+                logger.LogError("There was a problem creating contact information");
                 return;
             }
-
+            if (generatedSubscribeRecord.SubscriptionRecord == null)
+            {
+                logger.LogError("There was a problem creating contact information");
+                return;
+            }
+           
             logger.LogInformation("Contact information created successfully for report {_floodReportId}", _floodReportId);
-            navigationManager.NavigateTo(ContactPages.Home.Url);
+            navigationManager.NavigateTo(ContactPages.Summary.Url);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
This pull request updates the contact creation flow in the Flood Report Contacts feature to simplify dependencies, improve user identification, and ensure that contact and subscription records are handled more robustly. The most important changes are grouped below:

**Navigation and UI Consistency:**

* The "Cancel" button and navigation after contact creation now both redirect to the `ContactPages.Summary.Url` instead of `ContactPages.Home.Url`, ensuring consistent user experience. [[1]](diffhunk://#diff-bc71ceb3cc9811f33322e7806d55463bca5f944a6f79787c40d885b448389b2dL40-R40) [[2]](diffhunk://#diff-00bc6263c25a102483ab88fe3a913fddd77d41b40a299fc3aadb6b823e9269ecL147-R179)
* Breadcrumbs have been updated to reference the summary page for improved navigation clarity.

**Dependency and Parameter Refactoring:**

* Removed unused or unnecessary dependencies from the `Create` component, such as `IFloodReportRepository`, `IGovNotifyEmailSender`, and `IGdsJsInterop`. Added `ICurrentUserService` to support current user data retrieval.

**User Identification and Authentication:**

* Improved user identification by extracting the object identifier (`oid`) from the correct claim (`http://schemas.microsoft.com/identity/claims/objectidentifier`) and storing it in the `_userId` field for later use in record creation.

**Contact and Subscription Record Creation Logic:**

* Refactored the contact creation logic to:
  - Remove dependency on a pre-fetched flood report.
  - Always retrieve the flood report ID from session storage.
  - Check for existing contact records before creating a new one, ensuring only one contact record per report.
  - Create a subscription record after ensuring a contact record exists, and handle errors more robustly.

**Other Code Cleanups:**

* Removed unused code and parameters, such as commented-out notification logic and unnecessary GDS JS initialization. [[1]](diffhunk://#diff-00bc6263c25a102483ab88fe3a913fddd77d41b40a299fc3aadb6b823e9269ecL126-R111) [[2]](diffhunk://#diff-00bc6263c25a102483ab88fe3a913fddd77d41b40a299fc3aadb6b823e9269ecL147-R179)