### PR TITLE
PR11 - Add subscription verification pages

### DIFF
--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Subscribe/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Subscribe/Index.razor
@@ -1,0 +1,48 @@
+﻿@page "/floodreport/contacts/subscribe"
+
+<PageTitle>@Title</PageTitle>
+
+<GdsBreadcrumbs Items="Breadcrumbs" />
+
+<h1 class="govuk-heading-l">@Title</h1>
+
+<EditForm EditContext="_editContext" OnSubmit="OnSubmit" FormName="CreateSubscription">
+    <FluentValidationValidator />
+    <GdsErrorSummary />
+
+    <GdsFormGroup For="() => Model.ContactName">
+        <GdsLabel Text="Contact name" />
+        <GdsErrorMessage />
+        <GdsInputText @bind-Value="Model.ContactName" class="govuk-input govuk-input--width-20" spellcheck="false" autocomplete="name" />
+    </GdsFormGroup>
+
+    <GdsFormGroup For="() => Model.EmailAddress">
+        <GdsLabel Text="Email address" />
+        <GdsHint>
+            <div>We’ll only use this to send you a confirmation and for updates on your case.</div>
+            <div>Email addresses will be deleted within 6 months unless a further investigation is started.</div>
+        </GdsHint>
+        <GdsErrorMessage />
+        <GdsInputText @bind-Value="Model.EmailAddress" class="govuk-input" type="email" spellcheck="false" autocomplete="email" aria-describedby="EmailAddress-hint" />
+    </GdsFormGroup>
+
+    <GdsFormGroup For="() => Model.ContactType">
+        <InputRadioGroup @bind-Value="Model.ContactType">
+            <GdsFieldsetGroup>
+                <Heading>
+                    <h2 class="govuk-fieldset__heading">Who are you?</h2>
+                </Heading>
+                <Content>
+                    <GdsHint>Select one option.</GdsHint>
+                    <GdsErrorMessage />
+                    <GdsRadios Options="ContactTypes" />
+                </Content>
+            </GdsFieldsetGroup>
+        </InputRadioGroup>
+    </GdsFormGroup>
+
+    <div class="govuk-button-group">
+        <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">Save</button>
+        <a draggable="false" data-prevent-double-click="true" class="govuk-link govuk-link--no-visited-state" href="@FloodReportCreatePages.Confirmation.Url">Cancel</a>
+    </div>
+</EditForm>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Subscribe/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Subscribe/Index.razor.cs
@@ -1,0 +1,285 @@
+using FloodOnlineReportingTool.Contracts.Shared;
+using FloodOnlineReportingTool.Database.Models.Contact;
+using FloodOnlineReportingTool.Database.Models.Contact.Subscribe;
+using FloodOnlineReportingTool.Database.Repositories;
+using FloodOnlineReportingTool.Public.Models.FloodReport.Contact.Subscribe;
+using FloodOnlineReportingTool.Public.Models.Order;
+using FloodOnlineReportingTool.Public.Services;
+using GdsBlazorComponents;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace FloodOnlineReportingTool.Public.Components.Pages.FloodReport.Contacts.Subscribe;
+
+public partial class Index(
+    ILogger<Index> logger,
+    IContactRecordRepository contactRepository,
+    IGovNotifyEmailSender govNotifyEmailSender,
+    NavigationManager navigationManager,
+    SessionStateService scopedSessionStorage,
+    ICurrentUserService currentUserService
+) : IPageOrder, IAsyncDisposable
+{
+    private readonly CancellationTokenSource _cts = new();
+    private Guid _verificationId = Guid.Empty;
+    private Guid _floodReportId = Guid.Empty;
+    private Guid _userID = Guid.Empty;
+    private bool _isLoading = true;
+
+    [SupplyParameterFromQuery]
+    private bool Me { get; set; }
+
+    [SupplyParameterFromQuery]
+    private bool Owns { get; set; }
+
+    [CascadingParameter]
+    public Task<AuthenticationState>? AuthenticationState { get; set; }
+
+    [SupplyParameterFromQuery]
+    private bool FromSummary { get; set; }
+
+    private EditContext _editContext = default!;
+
+    public IReadOnlyCollection<GdsOptionItem<ContactRecordType>> ContactTypes = [];
+
+    public required SubscribeModel Model { get; set; } = default!;
+
+    private ValidationMessageStore _messageStore = default!;
+
+    // Page order properties
+    public string Title { get; set; } = SubscriptionPages.Home.Title;
+    public IReadOnlyCollection<GdsBreadcrumb> Breadcrumbs { get; set; } = [
+        GeneralPages.Home.ToGdsBreadcrumb(),
+        FloodReportPages.Overview.ToGdsBreadcrumb(),
+    ];
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await _cts.CancelAsync();
+            _cts.Dispose();
+        }
+        catch (Exception)
+        {
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Setup model and edit context
+        if (Model == null)
+        {
+            Model = new();
+            Model.ContactRecord = new();
+            _editContext = new(Model);
+            _editContext.SetFieldCssClassProvider(new GdsFieldCssClassProvider());
+            _messageStore = new(_editContext);
+            ContactTypes = CreateContactTypeOptions();
+        }
+
+        // Check if user is authenticated
+        if (AuthenticationState is not null)
+        {
+
+            var authState = await AuthenticationState;
+            var user = authState.User;
+
+            var oidClaim = user.FindFirst("http://schemas.microsoft.com/identity/claims/objectidentifier")?.Value;
+            _userID = Guid.TryParse(oidClaim, out var parsedOid) ? parsedOid : Guid.Empty;
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _verificationId = await scopedSessionStorage.GetVerificationId();
+
+            if (Me)
+            {
+                if (_userID == Guid.Empty)
+                {
+                    // Can't proceed if not authenticated
+                    navigationManager.NavigateTo(ContactPages.Summary.Url);
+                    return;
+                }
+                // Check if this user already has a contact record
+                var contactRecord = await contactRepository.ContactRecordExistsForUser(_userID, _cts.Token);
+                if (contactRecord != Guid.Empty)
+                {
+                    var contactRecordId = contactRecord.Value;
+                    // Connect to the existing record and skip the subscription setup steps
+                    _floodReportId = await scopedSessionStorage.GetFloodReportId();
+
+                    var linkResult = await contactRepository.LinkContactByReport(_floodReportId, contactRecordId, _cts.Token);
+                    if (linkResult.IsSuccess)
+                    {
+                        var recordOwner = await contactRepository.GetReportOwnerContactByReport(_floodReportId, _cts.Token);
+                        if (recordOwner == null) {
+                            // Can't proceed if not authenticated
+                            navigationManager.NavigateTo(ContactPages.Summary.Url);
+                            return;
+                        }
+
+                        // Store session info
+                        await scopedSessionStorage.SaveVerificationId(recordOwner.Id);
+
+                        // Proceed to summary
+                        var nextPageUrl = ContactPages.Summary.Url;
+                        navigationManager.NavigateTo(nextPageUrl);
+                        return;
+                    }
+                }
+
+                // Pre-fill email if known
+                if (string.IsNullOrWhiteSpace(Model.ContactName))
+                {
+                    Model.ContactName = currentUserService.Name;
+                }
+
+                if (string.IsNullOrWhiteSpace(Model.EmailAddress))
+                {
+                    Model.EmailAddress = currentUserService.Email;
+                }
+
+                // Notify EditContext of changes
+                if (!string.IsNullOrWhiteSpace(Model.ContactName))
+                {
+                    _editContext.NotifyFieldChanged(_editContext.Field(nameof(Model.ContactName)));
+                }
+                if (!string.IsNullOrWhiteSpace(Model.EmailAddress))
+                {
+                    _editContext.NotifyFieldChanged(_editContext.Field(nameof(Model.EmailAddress)));
+                }
+            }
+
+            _isLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnSubmit()
+    {
+        _messageStore.Clear();
+
+        if (!_editContext.Validate())
+        {
+            StateHasChanged();
+            return;
+        }
+
+        // Error handling back into the Razor. Use validation message store or ErrorBoundary
+
+        // Generate a contact record
+        _floodReportId = await scopedSessionStorage.GetFloodReportId();
+        ContactRecordDto dto = new ContactRecordDto
+            {
+                UserId = _userID == Guid.Empty ? null : _userID,
+                ContactType = Model.ContactType,
+                ContactName = Model.ContactName!,
+                EmailAddress = Model.EmailAddress!,
+                IsRecordOwner = Owns
+            };
+        var contactRecord = await contactRepository.GetContactsByReport(_floodReportId, _cts.Token);
+        Guid contactRecordId;
+        if (contactRecord.Count == 0)
+        {
+            var newRecord = await contactRepository.CreateForReport(_floodReportId, dto, _cts.Token);
+            if (!newRecord.IsSuccess)
+            {
+                CustomLogError(nameof(Model.ErrorMessage), "Couldn't create a subscription record.", "Sorry, something went wrong", true);
+                return;
+            }
+            contactRecordId = newRecord.ContactRecord!.Id;
+        } else
+        {
+            contactRecordId = contactRecord.First().Id;
+        }
+        SubscribeCreateOrUpdateResult subscriptionResult = await contactRepository.CreateSubscriptionRecord(contactRecordId, dto, currentUserService.Email, true, _cts.Token);
+        
+        if (subscriptionResult.SubscriptionRecord is not SubscribeRecord returnedSubscription)
+        {
+            CustomLogError(nameof(Model.ErrorMessage), "Created subscription record not returned.", "Sorry, something went wrong", true);
+            return;
+        }
+        if (returnedSubscription.VerificationExpiryUtc is not DateTimeOffset expiry)
+        {
+            CustomLogError(nameof(Model.ErrorMessage), "Subscription record verification expiry is not valid.", "Sorry, something went wrong", true);
+            return;
+        }
+
+        // Success
+        // We are past the point of no return - all errors from here need to be passed to the next page
+        // Use try catch and pass errors via query string or session storage if needed
+
+        // Store session info
+        await scopedSessionStorage.SaveVerificationId(returnedSubscription.Id);
+
+        if (returnedSubscription.IsEmailVerified)
+        {
+            // Send them onwards
+            var nextPageUrl = ContactPages.Summary.Url;
+            navigationManager.NavigateTo(nextPageUrl);
+        } else
+        {
+            // send confirmation email
+            try
+            {
+                logger.LogInformation("Sending email verification notification");
+                var sentNotification = await govNotifyEmailSender.SendEmailVerificationNotification(
+                    returnedSubscription.EmailAddress,
+                    returnedSubscription.ContactName,
+                    returnedSubscription.VerificationCode,
+                    expiry
+                    );
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error sending email verification notification: {ErrorMessage}", ex.Message);
+            }
+
+            // Send them onwards
+            var nextPageUrl = SubscriptionPages.Verify.Url;
+            if (FromSummary)
+            {
+                nextPageUrl = ContactPages.Summary.Url;
+            }
+            var NavigationOptions = new NavigationOptions
+            {
+
+            };
+            // TODO: pass that the email sending failed if emailSent is false
+            navigationManager.NavigateTo(nextPageUrl);
+        }
+            
+    }
+
+    private void CustomLogError(string fieldname, string errorMessage, string returnMessage, bool logMessage)
+    {
+        if (logMessage)
+        {
+            logger.LogWarning(errorMessage);
+        }
+        _messageStore.Add(_editContext.Field(fieldname), returnMessage);
+        _editContext.NotifyValidationStateChanged();
+    }
+
+    private IReadOnlyCollection<GdsOptionItem<ContactRecordType>> CreateContactTypeOptions()
+    {
+
+        var allTypes = Enum.GetValues<ContactRecordType>();
+
+        return [.. allTypes.Select(CreateOption)];
+    }
+
+    private GdsOptionItem<ContactRecordType> CreateOption(ContactRecordType contactRecordType)
+    {
+        var id = contactRecordType.ToString().AsSpan();
+        var selected = false;
+        return new GdsOptionItem<ContactRecordType>(id, contactRecordType.LabelText(), contactRecordType, selected, hint: contactRecordType.HintText());
+    }
+}

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Subscribe/Verify.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Subscribe/Verify.razor
@@ -1,0 +1,36 @@
+﻿@page "/floodreport/contacts/subscribe/verify"
+
+<PageTitle>@Title</PageTitle>
+
+<GdsBreadcrumbs Items="Breadcrumbs" />
+
+<h1 class="govuk-heading-l">@Title</h1>
+
+<p>Please enter the <strong>6-digit verification code</strong> sent to your email address.</p>
+<p>The code is valid for 30 minutes.</p>
+
+<EditForm EditContext="_editContext" OnSubmit="OnSubmit" FormName="VerificationForm">
+    <FluentValidationValidator />
+    <GdsErrorSummary />
+
+    <GdsSpinner Show="_isLoading" ShowMessage="true" />
+
+    <GdsFormGroup For="() => Model.EnteredCodeText">
+        <GdsLabel Text="Verification code" />
+        <GdsHint>Enter the 6-digit code (numbers only).</GdsHint>
+        <GdsErrorMessage />
+        <GdsInputNumber @bind-Value="Model.EnteredCodeText" @bind-NumberValue="Model.EnteredCodeNumber" class="govuk-input govuk-input--width-10" />
+    </GdsFormGroup>
+
+    <div class="govuk-button-group">
+        <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">Verify</button>
+        <button type="button" data-prevent-double-click="true" class="govuk-button govuk-button--secondary" data-module="govuk-button" @onclick="OnResend">Resend code</button>
+    </div>
+
+    @if (isResent != null)
+    {
+        <div class="govuk-inset-text">
+            @((bool)isResent ? "A new verification code has been sent to your email address." : "Unable to resend code. Please try again later.")
+        </div>
+    }
+</EditForm>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Subscribe/Verify.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Subscribe/Verify.razor.cs
@@ -1,0 +1,176 @@
+using FloodOnlineReportingTool.Database.Models.Contact.Subscribe;
+using FloodOnlineReportingTool.Database.Repositories;
+using FloodOnlineReportingTool.Public.Models.FloodReport.Contact.Subscribe;
+using FloodOnlineReportingTool.Public.Models.Order;
+using FloodOnlineReportingTool.Public.Services;
+using GdsBlazorComponents;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace FloodOnlineReportingTool.Public.Components.Pages.FloodReport.Contacts.Subscribe;
+
+public partial class Verify(
+    ILogger<Verify> logger,
+    IContactRecordRepository contactRepository,
+    IGovNotifyEmailSender govNotifyEmailSender,
+    SessionStateService scopedSessionStorage,
+    NavigationManager navigationManager
+) : IPageOrder, IAsyncDisposable
+{
+    private readonly CancellationTokenSource _cts = new();
+    private Guid _verificationId = Guid.Empty;
+    private Guid _floodReportId = Guid.Empty;
+    private SubscribeRecord? _subscribeRecord;
+    private bool _isLoading = true;
+    private bool? isResent;
+
+    // Page order properties
+    public string Title { get; set; } = SubscriptionPages.Verify.Title;
+    public IReadOnlyCollection<GdsBreadcrumb> Breadcrumbs { get; set; } = [
+        GeneralPages.Home.ToGdsBreadcrumb(),
+        FloodReportPages.Overview.ToGdsBreadcrumb(),
+    ];
+
+    private EditContext _editContext = default!;
+
+    private VerifyModel Model { get; set; } = default!;
+
+    private ValidationMessageStore _messageStore = default!;
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await _cts.CancelAsync();
+            _cts.Dispose();
+        }
+        catch (Exception)
+        {
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    protected override void OnInitialized()
+    {
+        // Setup model and edit context
+        Model ??= new();
+        _editContext = new(Model);
+        _editContext.SetFieldCssClassProvider(new GdsFieldCssClassProvider());
+        _messageStore = new(_editContext);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _verificationId = await scopedSessionStorage.GetVerificationId();
+
+            _subscribeRecord = await contactRepository.GetSubscriptionRecordById(_verificationId, _cts.Token);
+            if (_subscribeRecord == null)
+            {
+                logger.LogWarning("No subscription record found for verification ID {VerificationId}", _verificationId);
+                // Handle missing subscription record as needed
+                _isLoading = false;
+                StateHasChanged();
+                return;
+            }
+
+            Model = new VerifyModel
+            {
+                Id = _subscribeRecord.Id,
+                ContactName = _subscribeRecord.ContactName,
+                EmailAddress = _subscribeRecord.EmailAddress,
+                IsEmailVerified = _subscribeRecord.IsEmailVerified,
+                ContactType = _subscribeRecord.ContactType,
+            };
+
+            // Recreate the EditContext with the new Model instance
+            _editContext = new(Model);
+            _editContext.SetFieldCssClassProvider(new GdsFieldCssClassProvider());
+            _messageStore = new(_editContext);
+
+            _isLoading = false;
+            StateHasChanged();
+            
+        }
+    }
+
+    private async Task OnSubmit()
+    {
+        _messageStore.Clear();
+
+        if (!_editContext.Validate())
+        {
+            StateHasChanged();
+            return;
+        }
+        if (Model.EnteredCodeNumber is not int enteredCode)
+        {
+            StateHasChanged();
+            return;
+        }
+
+        bool VerifiedResult = await contactRepository.VerifySubscriptionRecord(Model.Id, enteredCode, _cts.Token);
+
+        if (!VerifiedResult)
+        {
+            CustomLogError(nameof(Model.EnteredCodeNumber),"Incorrect verification code entered.", "The code you provided was not correct. Please try again or request a new code.", false);
+            _editContext.NotifyValidationStateChanged();
+            return;
+        }
+        navigationManager.NavigateTo(ContactPages.Summary.Url);
+    }
+
+    private async Task OnResend()
+    {
+        isResent = false;
+
+        var subscribeRecord = await contactRepository.GetSubscriptionRecordById(_verificationId, _cts.Token);
+        if ( subscribeRecord == null)
+        {
+            StateHasChanged();
+            return;
+        }
+        var updatedSubscription = await contactRepository.UpdateVerificationCode(subscribeRecord, true, _cts.Token);
+        if (updatedSubscription.SubscriptionRecord is not SubscribeRecord returnedSubscription)
+        {
+            StateHasChanged();
+            return;
+        }
+        if (returnedSubscription.VerificationExpiryUtc is not DateTimeOffset expiry)
+        {
+            StateHasChanged();
+            return;
+        }
+
+        try
+        {
+            logger.LogInformation("Sending email verification notification");
+            var sentNotification = await govNotifyEmailSender.SendEmailVerificationNotification(
+                returnedSubscription.EmailAddress,
+                returnedSubscription.ContactName,
+                returnedSubscription.VerificationCode,
+                expiry
+                );
+            isResent = true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error sending email verification notification: {ErrorMessage}", ex.Message);
+        }
+
+        StateHasChanged();
+        return;
+    }
+
+    private void CustomLogError(string fieldname, string errorMessage, string returnMessage, bool logMessage)
+    {
+        if (logMessage)
+        {
+            logger.LogWarning(errorMessage);
+        }
+        _messageStore.Add(_editContext.Field(fieldname), returnMessage);
+        _editContext.NotifyValidationStateChanged();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new email subscription and verification workflow for flood report contacts. It adds two new pages: one for users to subscribe with their contact details and another for verifying their email via a 6-digit code. The implementation includes UI forms, validation, session management, and integration with backend services for contact and subscription record handling.

The most important changes are:

**New Subscription Workflow:**

* Added a new subscription form page (`Index.razor` and `Index.razor.cs`) where users can enter their contact name, email address, and select their contact type. The backend logic handles pre-filling data for authenticated users, contact record creation/linking, and sending a verification email if needed. [[1]](diffhunk://#diff-4d1fd40db63e5f0db2e090ac2f13be07897c988c15a8e8670eecbcc39a781257R1-R48) [[2]](diffhunk://#diff-b9a5838bd3c8465d0d3a6425d7ada359a48b993e8947dbb679ec12b8e8d15740R1-R285)

**Email Verification Process:**

* Introduced a verification page (`Verify.razor` and `Verify.razor.cs`) that prompts users to enter a 6-digit code sent to their email. The backend logic verifies the code, allows resending the code, and manages error handling and navigation on success or failure. [[1]](diffhunk://#diff-dcfc921e4af627c7cad181622317153ba7dd3bc904ac3271df9e1bacd749d1a9R1-R36) [[2]](diffhunk://#diff-52a0dba3cc17b33cebd735b7e73ef964476d16eb259ddde0951f409e5c107697R1-R176)

**Integration and State Management:**

* Implemented session state management to persist verification and report IDs across steps, and used dependency-injected services for contact repository access, email sending, and user context throughout the workflow. [[1]](diffhunk://#diff-b9a5838bd3c8465d0d3a6425d7ada359a48b993e8947dbb679ec12b8e8d15740R1-R285) [[2]](diffhunk://#diff-52a0dba3cc17b33cebd735b7e73ef964476d16eb259ddde0951f409e5c107697R1-R176)

**User Experience Enhancements:**

* Provided clear error handling, validation, and user feedback (including loading spinners and success/error messages) to ensure a smooth user journey through the subscription and verification process. [[1]](diffhunk://#diff-4d1fd40db63e5f0db2e090ac2f13be07897c988c15a8e8670eecbcc39a781257R1-R48) [[2]](diffhunk://#diff-dcfc921e4af627c7cad181622317153ba7dd3bc904ac3271df9e1bacd749d1a9R1-R36) [[3]](diffhunk://#diff-b9a5838bd3c8465d0d3a6425d7ada359a48b993e8947dbb679ec12b8e8d15740R1-R285) [[4]](diffhunk://#diff-52a0dba3cc17b33cebd735b7e73ef964476d16eb259ddde0951f409e5c107697R1-R176)