### PR TITLE
Bugfix for logging in whilst reporting a new flood

### DIFF
--- a/FloodOnlineReportingTool.Public/Authentication/AuthenticationFlow.cs
+++ b/FloodOnlineReportingTool.Public/Authentication/AuthenticationFlow.cs
@@ -3,18 +3,12 @@
 internal static class AuthenticationFlow
 {
     public static readonly string[] AuthPaths = [
-        "signin",
-        "signout",
-        "signedout",
         "account/signin",
         "account/sign-in",
         "account/signout",
         "account/sign-out",
         "account/signedout",
         "account/signed-out",
-        "/signin",
-        "/signout",
-        "/signedout",
         "/account/signin",
         "/account/sign-in",
         "/account/signout",

--- a/FloodOnlineReportingTool.Public/Components/Layout/MainLayout.razor
+++ b/FloodOnlineReportingTool.Public/Components/Layout/MainLayout.razor
@@ -6,7 +6,7 @@
     <NavLinks>
         <AuthorizeView>
             <Authorized>
-                <GdsHeaderNavLink Href="signout" Match="NavLinkMatch.All">Sign out</GdsHeaderNavLink>
+                <GdsHeaderNavLink Href="@AccountPages.SignOut.Url" Match="NavLinkMatch.All">Sign out</GdsHeaderNavLink>
             </Authorized>
             <NotAuthorized>
                 <GdsHeaderNavLink Href="@_signInUrl" Match="NavLinkMatch.All">Sign in</GdsHeaderNavLink>
@@ -69,7 +69,7 @@
         get
         {
             var redirectUri = Navigation.SignInRedirectUri;
-            return string.IsNullOrWhiteSpace(redirectUri) ? "signin" : $"signin?redirectUri={redirectUri}";
+            return string.IsNullOrWhiteSpace(redirectUri) ? AccountPages.SignIn.Url : $"{AccountPages.SignIn.Url}?redirectUri={redirectUri}";
         }
     }
 }

--- a/FloodOnlineReportingTool.Public/Components/Pages/Account/SignedOut.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/Account/SignedOut.razor
@@ -1,4 +1,4 @@
-﻿@page "/Account/signedout"
+﻿@page "/account/signedout"
 @using Microsoft.AspNetCore.Authorization
 @attribute [AllowAnonymous]
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor
@@ -1,4 +1,5 @@
 ﻿@page "/floodreport/contacts/change/{contactid:guid}"
+@page "/floodreport/contacts/change"
 @using Microsoft.AspNetCore.Components.Authorization
 
 <PageTitle>@Title</PageTitle>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor.cs
@@ -187,6 +187,12 @@ public partial class Change(
     {
         _messageStore.Clear();
 
+        if (_contactModel is null)
+        {
+            logger.LogWarning("Contact model is null, cannot submit form");
+            return;
+        }
+
         // Manual FluentValidation - only runs on submit to avoid premature validation errors
         var validator = new ContactModelValidator();
         var validationResult = await validator.ValidateAsync(_contactModel, _cts.Token);

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor.cs
@@ -101,6 +101,13 @@ public partial class Change(
         {
             // Retrieve the flood report ID from session storage
             _floodReportId = await scopedSessionStorage.GetFloodReportId();
+            var reportOwnerSubscribeRecord = await contactRepository.GetReportOwnerContactByReport(_floodReportId, _cts.Token);
+            if (reportOwnerSubscribeRecord is null)
+            {
+                // This is not allowed, setup an owner
+                navigationManager.NavigateTo(SubscriptionPages.Home.Url);
+                return;
+            }
 
             // Load the subscription record for the contact
             _subscribeModel = await contactRepository.GetSubscriptionRecordById(ContactId, _cts.Token);

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor.cs
@@ -105,7 +105,7 @@ public partial class Change(
             if (reportOwnerSubscribeRecord is null)
             {
                 // This is not allowed, setup an owner
-                navigationManager.NavigateTo(SubscriptionPages.Home.Url);
+                navigationManager.NavigateTo($"{SubscriptionPages.Home.Url}?Owns=true");
                 return;
             }
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Change.razor.cs
@@ -34,7 +34,7 @@ public partial class Change(
     // Parameters
 
     [Parameter]
-    public Guid ContactId { get; set; }
+    public Guid? ContactId { get; set; }
 
     [CascadingParameter]
     public Task<AuthenticationState>? AuthenticationState { get; set; }
@@ -49,6 +49,7 @@ public partial class Change(
     private ContactModel? _contactModel;
     private SubscribeRecord? _subscribeModel;
     private Guid _floodReportId = Guid.Empty;
+    private Guid _contactId = Guid.Empty;
     private string? _userID;
     private bool _isLoading = true;
     private bool _isDataLoading = true;
@@ -99,6 +100,15 @@ public partial class Change(
 
         try
         {
+            if (ContactId is null)
+            {
+                logger.LogWarning("ContactId parameter is null, cannot load contact data");
+                navigationManager.NavigateTo(ContactPages.Summary.Url);
+                return;
+            }
+
+            _contactId = ContactId ?? Guid.Empty;
+
             // Retrieve the flood report ID from session storage
             _floodReportId = await scopedSessionStorage.GetFloodReportId();
             var reportOwnerSubscribeRecord = await contactRepository.GetReportOwnerContactByReport(_floodReportId, _cts.Token);
@@ -110,7 +120,7 @@ public partial class Change(
             }
 
             // Load the subscription record for the contact
-            _subscribeModel = await contactRepository.GetSubscriptionRecordById(ContactId, _cts.Token);
+            _subscribeModel = await contactRepository.GetSubscriptionRecordById(_contactId, _cts.Token);
             if (_subscribeModel is not null)
             {
                 // Map subscription data to contact model for editing
@@ -129,7 +139,7 @@ public partial class Change(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error loading contact data for ContactId {ContactId}", ContactId);
+            logger.LogError(ex, "Error loading contact data");
         }
         finally
         {
@@ -200,7 +210,7 @@ public partial class Change(
 
     private async Task UpdateContactAsync()
     {
-        logger.LogDebug("Updating contact information for ContactId {ContactId}", ContactId);
+        logger.LogDebug("Updating contact information");
 
         if (_contactModel is null)
         {
@@ -211,10 +221,10 @@ public partial class Change(
         try
         {
             // Retrieve the current subscription record
-            var selectedRecord = await contactRepository.GetSubscriptionRecordById(ContactId, _cts.Token);
+            var selectedRecord = await contactRepository.GetSubscriptionRecordById(_contactId, _cts.Token);
             if (selectedRecord is null)
             {
-                logger.LogWarning("Subscription record not found for ContactId {ContactId}", ContactId);
+                logger.LogWarning("Subscription record not found");
                 return;
             }
 
@@ -226,11 +236,11 @@ public partial class Change(
 
             var updatedSubscription = await contactRepository.UpdateSubscriptionRecord(selectedRecord, _cts.Token);
 
-            logger.LogInformation("Contact information updated successfully for ContactId {ContactId}", ContactId);
+            logger.LogInformation("Contact information updated successfully");
 
             if (updatedSubscription.ResultModel is not SubscribeRecord sub)
             {
-                logger.LogError("Failed to update subscription record for ContactId {ContactId}", ContactId);
+                logger.LogError("Failed to update subscription record");
                 return;
             }
 
@@ -245,7 +255,7 @@ public partial class Change(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error updating contact information for ContactId {ContactId}", ContactId);
+            logger.LogError(ex, "Error updating contact information");
             _messageStore.Add(_editContext.Field(nameof(_contactModel.ContactType)), "There was a problem updating the contact information. Please try again but if this issue persists then please report a bug.");
             _editContext.NotifyValidationStateChanged();
         }
@@ -270,7 +280,7 @@ public partial class Change(
                 return;
             }
 
-            logger.LogInformation("Sending email verification notification to {EmailAddress}", returnedSubscription.EmailAddress);
+            logger.LogInformation("Sending email verification notification");
 
             // TODO: Implement proper verification link generation
             // The verification link should include the verification code and subscription ID

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor.cs
@@ -97,7 +97,7 @@ public partial class Create(
             if (reportOwnerSubscribeRecord is null)
             {
                 // This is not allowed, setup an owner
-                navigationManager.NavigateTo($"{SubscriptionPages.Subscribe.Url}?Owns=true");
+                navigationManager.NavigateTo($"{SubscriptionPages.Home.Url}?Owns=true");
                 return;
             }
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor.cs
@@ -93,6 +93,13 @@ public partial class Create(
         if (firstRender)
         {           
             _floodReportId = await scopedSessionStorage.GetFloodReportId();
+            var reportOwnerSubscribeRecord = await contactRepository.GetReportOwnerContactByReport(_floodReportId, _cts.Token);
+            if (reportOwnerSubscribeRecord is null)
+            {
+                // This is not allowed, setup an owner
+                navigationManager.NavigateTo(SubscriptionPages.Home.Url);
+                return;
+            }
 
             // This is a create page, so we need to get the unused contact types only
             var allTypes = await contactRepository.GetUnusedRecordTypes(_floodReportId, _cts.Token);

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Create.razor.cs
@@ -97,7 +97,7 @@ public partial class Create(
             if (reportOwnerSubscribeRecord is null)
             {
                 // This is not allowed, setup an owner
-                navigationManager.NavigateTo(SubscriptionPages.Home.Url);
+                navigationManager.NavigateTo($"{SubscriptionPages.Subscribe.Url}?Owns=true");
                 return;
             }
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Delete.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Delete.razor
@@ -1,4 +1,5 @@
 ﻿@page "/floodreport/contacts/delete/{contactid:guid}"
+@page "/floodreport/contacts/delete"
 @using FloodOnlineReportingTool.Contracts.Shared
 @using Microsoft.AspNetCore.Components.Authorization
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Delete.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Delete.razor.cs
@@ -29,7 +29,7 @@ public partial class Delete(
 
     // Parameters
     [Parameter]
-    public Guid ContactId { get; set; }
+    public Guid? ContactId { get; set; }
 
     [CascadingParameter]
     public Task<AuthenticationState>? AuthenticationState { get; set; }
@@ -39,6 +39,7 @@ public partial class Delete(
     private EditContext _editContext = default!;
     private ValidationMessageStore _messageStore = default!;
     private Guid _floodReportId = Guid.Empty;
+    private Guid _contactId = Guid.Empty;
     private string _floodReportReference = string.Empty;
     private Guid _userId;
     private bool _isLoading = true;
@@ -64,6 +65,14 @@ public partial class Delete(
     {
         if (firstRender)
         {
+            if (ContactId is null)
+            {
+                logger.LogWarning("ContactId parameter is null, cannot load contact data");
+                navigationManager.NavigateTo(ContactPages.Summary.Url);
+                return;
+            }
+            _contactId = ContactId ?? Guid.Empty;
+
             _floodReportId = await scopedSessionStorage.GetFloodReportId();
 
             var reportOwnerSubscribeRecord = await contactRepository.GetReportOwnerContactByReport(_floodReportId, _cts.Token);
@@ -144,7 +153,7 @@ public partial class Delete(
         _deletePermited = false;
         _floodReportReference = string.Empty;
 
-        var contactRecord = await contactRepository.GetContactById(ContactId, _cts.Token);
+        var contactRecord = await contactRepository.GetContactById(_contactId, _cts.Token);
         if (contactRecord == null)
         {
             return null;

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Delete.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Delete.razor.cs
@@ -70,7 +70,7 @@ public partial class Delete(
             if (reportOwnerSubscribeRecord is null)
             {
                 // This is not allowed, setup an owner
-                navigationManager.NavigateTo(SubscriptionPages.Home.Url);
+                navigationManager.NavigateTo($"{SubscriptionPages.Home.Url}?Owns=true");
                 return;
             }
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Delete.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Delete.razor.cs
@@ -66,6 +66,14 @@ public partial class Delete(
         {
             _floodReportId = await scopedSessionStorage.GetFloodReportId();
 
+            var reportOwnerSubscribeRecord = await contactRepository.GetReportOwnerContactByReport(_floodReportId, _cts.Token);
+            if (reportOwnerSubscribeRecord is null)
+            {
+                // This is not allowed, setup an owner
+                navigationManager.NavigateTo(SubscriptionPages.Home.Url);
+                return;
+            }
+
             // Setup model and edit context
             if (_contactModel == null)
             {

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Summary.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Summary.razor.cs
@@ -94,6 +94,13 @@ public partial class Summary(
         var reportOwnerSubscribeRecord = await contactRepository.GetReportOwnerContactByReport(_floodReportId, _cts.Token);
         _reportOwnerContact = reportOwnerSubscribeRecord?.ToContactModel();
 
+        if (_reportOwnerContact is null)
+        {
+            // This is not allowed, setup an owner
+            navigationManager.NavigateTo(SubscriptionPages.Home.Url);
+            return;
+        }
+
         var allContactRecords = await contactRepository.GetContactsByReport(_floodReportId, _cts.Token);
 
         // Filter out the report owner from the additional contacts list

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Summary.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Contacts/Summary.razor.cs
@@ -97,7 +97,7 @@ public partial class Summary(
         if (_reportOwnerContact is null)
         {
             // This is not allowed, setup an owner
-            navigationManager.NavigateTo(SubscriptionPages.Home.Url);
+            navigationManager.NavigateTo($"{SubscriptionPages.Home.Url}?Owns=true");
             return;
         }
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Confirmation.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Confirmation.razor
@@ -88,7 +88,11 @@
 
                                 <li class="govuk-task-list__item govuk-task-list__item--with-link" aria-describedby="report-and-check-2-contacts">
                                     <div class="govuk-task-list__name-and-hint">
-                                        <a href="@($"signin?redirectUri={Uri.EscapeDataString($"{SubscriptionPages.Home.Url}?Me=true&Owns=true")}")" class="govuk-link govuk-task-list__link govuk-link--no-visited-state">Register/Login</a> to manage your report
+                                        @{
+                                            var redirectTargetUrl = $"{SubscriptionPages.Home.Url}?Me=true&Owns=true";
+                                            var signInUrl = $"signin?redirectUri={Uri.EscapeDataString(redirectTargetUrl)}";
+                                        }
+                                        <a href="@signInUrl" class="govuk-link govuk-task-list__link govuk-link--no-visited-state">Register/Login</a> to manage your report
                                         <div id="report-and-check-2-contacts-login-hint" class="govuk-task-list__hint">
                                             You will be allowed to login and manage your notifications and reports on this website.
                                         </div>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Confirmation.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Confirmation.razor
@@ -9,6 +9,11 @@
 
 <GdsSpinner Show="_isLoading" />
 
+@{
+    var signInUrl = $"{AccountPages.SignIn.Url}?redirectUri={Uri.EscapeDataString(_redirectTargetUrl)}";
+    var me = "";
+}
+
 @if (_loadingError)
 {
     <h1 class="govuk-heading-xl">@Title</h1>
@@ -88,10 +93,7 @@
 
                                 <li class="govuk-task-list__item govuk-task-list__item--with-link" aria-describedby="report-and-check-2-contacts">
                                     <div class="govuk-task-list__name-and-hint">
-                                        @{
-                                            var redirectTargetUrl = $"{SubscriptionPages.Home.Url}?Me=true&Owns=true";
-                                            var signInUrl = $"signin?redirectUri={Uri.EscapeDataString(redirectTargetUrl)}";
-                                        }
+                                        
                                         <a href="@signInUrl" class="govuk-link govuk-task-list__link govuk-link--no-visited-state">Register/Login</a> to manage your report
                                         <div id="report-and-check-2-contacts-login-hint" class="govuk-task-list__hint">
                                             You will be allowed to login and manage your notifications and reports on this website.
@@ -175,7 +177,7 @@
                 </ul>
                 <p>Using an account is the best way to manage your record and allows you to edit the information you have provided.</p>
                 <p>
-                    <button type="button" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@AccountPages.SignIn.Url">Register / Sign in</button>          
+                    <GdsStartButton Href="@signInUrl" Text="Register / Sign in" />
                 </p>
                 <p>
                     If you don't wish to use an account you can 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Confirmation.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Confirmation.razor
@@ -88,7 +88,7 @@
 
                                 <li class="govuk-task-list__item govuk-task-list__item--with-link" aria-describedby="report-and-check-2-contacts">
                                     <div class="govuk-task-list__name-and-hint">
-                                        <a href="@($"signin?redirectUri={Uri.EscapeDataString(ContactPages.Summary.Url)}")" class="govuk-link govuk-task-list__link govuk-link--no-visited-state">Register/Login</a> to manage your report
+                                        <a href="@($"signin?redirectUri={Uri.EscapeDataString($"{SubscriptionPages.Home.Url}?Me=true&Owns=true")}")" class="govuk-link govuk-task-list__link govuk-link--no-visited-state">Register/Login</a> to manage your report
                                         <div id="report-and-check-2-contacts-login-hint" class="govuk-task-list__hint">
                                             You will be allowed to login and manage your notifications and reports on this website.
                                         </div>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Confirmation.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Confirmation.razor.cs
@@ -22,6 +22,8 @@ public partial class Confirmation(
     private bool _loadingError;
     private Guid _FloodReportId;
     private bool _hasContactInformation;
+    
+    private string _redirectTargetUrl = $"{SubscriptionPages.Home.Url}?Me=true&Owns=true";
 
     // Public Properties
     public string Title { get; set; } = FloodReportCreatePages.Confirmation.Title;

--- a/FloodOnlineReportingTool.Public/Components/Pages/Test.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/Test.razor
@@ -35,7 +35,7 @@
                         <dt class="govuk-summary-list__key">Fort user is signed in</dt>
                         <dd class="govuk-summary-list__value">true</dd>
                         <dd class="govuk-summary-list__actions">
-                            <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-link" data-module="govuk-button" href="@($"{AccountPages.SignOut.Url}?returnUrl={GeneralPages.Test.Url}")">@AccountPages.SignOut.Title</a>
+                            <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-link" data-module="govuk-button" href="@($"{AccountPages.SignOut.Url}?returnUrl={GeneralPages.Test.Url}")">Sign Out</a>
                         </dd>
                     </div>
                     <div class="govuk-summary-list__row">

--- a/FloodOnlineReportingTool.Public/Components/Pages/Test.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/Test.razor.cs
@@ -92,7 +92,7 @@ public partial class Test(
         get
         {
             var redirectUri = navigationManager.SignInRedirectUri;
-            return string.IsNullOrWhiteSpace(redirectUri) ? "signin" : $"signin?redirectUri={redirectUri}";
+            return string.IsNullOrWhiteSpace(redirectUri) ? AccountPages.SignIn.Url : $"{AccountPages.SignIn.Url}?redirectUri={redirectUri}";
         }
     }
 

--- a/FloodOnlineReportingTool.Public/Endpoints/Account/AccountEndpoints.cs
+++ b/FloodOnlineReportingTool.Public/Endpoints/Account/AccountEndpoints.cs
@@ -75,16 +75,6 @@ internal static class AccountEndpoints
         return TypedResults.Challenge(properties, [CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme]);
     }
 
-    //internal static Results<ChallengeHttpResult, UnauthorizedHttpResult, ForbidHttpResult> AccountSignIn(
-    //    IOptions<GISOptions> options,
-    //    string? returnUrl,
-    //    string? loginHint,
-    //    string? domainHint
-    //) {
-    //    // pass returnUrl to redirectUri
-    //    return SignIn(options, returnUrl, loginHint, domainHint);
-    //}
-
     internal static Results<SignOutHttpResult, UnauthorizedHttpResult> SignOut(IOptions<GISOptions> options)
     {
         var properties = new AuthenticationProperties

--- a/FloodOnlineReportingTool.Public/Endpoints/Account/AccountEndpoints.cs
+++ b/FloodOnlineReportingTool.Public/Endpoints/Account/AccountEndpoints.cs
@@ -75,21 +75,21 @@ internal static class AccountEndpoints
         return TypedResults.Challenge(properties, [CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme]);
     }
 
-    internal static Results<ChallengeHttpResult, UnauthorizedHttpResult, ForbidHttpResult> AccountSignIn(
-        IOptions<GISOptions> options,
-        string? returnUrl,
-        string? loginHint,
-        string? domainHint
-    ) {
-        // pass returnUrl to redirectUri
-        return SignIn(options, returnUrl, loginHint, domainHint);
-    }
+    //internal static Results<ChallengeHttpResult, UnauthorizedHttpResult, ForbidHttpResult> AccountSignIn(
+    //    IOptions<GISOptions> options,
+    //    string? returnUrl,
+    //    string? loginHint,
+    //    string? domainHint
+    //) {
+    //    // pass returnUrl to redirectUri
+    //    return SignIn(options, returnUrl, loginHint, domainHint);
+    //}
 
     internal static Results<SignOutHttpResult, UnauthorizedHttpResult> SignOut(IOptions<GISOptions> options)
     {
         var properties = new AuthenticationProperties
         {
-            RedirectUri = $"/{options.Value.PathBase}/Account/signedout",
+            RedirectUri = $"/{options.Value.PathBase}/account/signedout",
         };
 
         return TypedResults.SignOut(properties, [CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme]);

--- a/FloodOnlineReportingTool.Public/Extensions/AuthenticationExtensions.cs
+++ b/FloodOnlineReportingTool.Public/Extensions/AuthenticationExtensions.cs
@@ -91,18 +91,13 @@ internal static class AuthenticationExtensions
 
     internal static WebApplication MapAuthenticationEndpoints(this WebApplication app)
     {
-        app.MapGet("signin", AccountEndpoints.SignIn)
-            .WithTags("Account")
-            .WithDisplayName("Sign in")
-            .WithSummary("Signs the user into the application")
-            .AllowAnonymous();
-        app.MapGet("account/signin", AccountEndpoints.AccountSignIn)
+        app.MapGet("account/signin", AccountEndpoints.SignIn)
             .WithTags("Account")
             .WithDisplayName("Microsoft Identity sign in")
             .WithSummary("Signs the user into the application")
             .AllowAnonymous();
 
-        app.MapGet("signout", AccountEndpoints.SignOut)
+        app.MapGet("account/signout", AccountEndpoints.SignOut)
             .WithTags("Account")
             .WithDisplayName("Sign out")
             .WithSummary("Signs the user out of the application.")

--- a/FloodOnlineReportingTool.Public/Extensions/AuthenticationExtensions.cs
+++ b/FloodOnlineReportingTool.Public/Extensions/AuthenticationExtensions.cs
@@ -93,7 +93,7 @@ internal static class AuthenticationExtensions
     {
         app.MapGet("account/signin", AccountEndpoints.SignIn)
             .WithTags("Account")
-            .WithDisplayName("Microsoft Identity sign in")
+            .WithDisplayName("Sign in")
             .WithSummary("Signs the user into the application")
             .AllowAnonymous();
 

--- a/FloodOnlineReportingTool.Public/Models/Order/AccountPages.cs
+++ b/FloodOnlineReportingTool.Public/Models/Order/AccountPages.cs
@@ -5,7 +5,8 @@ internal static class AccountPages
     private static ReadOnlySpan<char> BaseUrl => "account";
 
     public static readonly PageInfo SignIn = new(BaseUrl, "/signin", "Sign in");
-    public static readonly PageInfo SignOut = new(BaseUrl, "/signedout", "Signed out");
+    public static readonly PageInfo SignOut = new(BaseUrl, "/signout", "Sign out");
+    public static readonly PageInfo SignedOut = new(BaseUrl, "/signedout", "Signed out");
     public static readonly PageInfo MyAccount = new(BaseUrl, "/myaccount", "My Account");
     //public static readonly PageInfo SignIn = new(BaseUrl, "/signin", "Sign in");
     //public static readonly PageInfo SignOut = new(BaseUrl, "/signout", "Sign out");


### PR DESCRIPTION
If a user clicks register/login on the confirmation page they are redirected to the wrong page in the contacts area of the site. 

This PR fixes this so that users are routed back to the page that sets up the initial user record. 

I've also added logic to prevent users from accessing any contacts pages if there is no report owner as the logic is that there must be a report owner and the owner may add additional contacts. There should be no access unless you have an owner record. 

Closes #122