### PR TITLE
Updated the index page

### DIFF
--- a/Database/EntitiesConfiguration/ContactRecordConfiguration.cs
+++ b/Database/EntitiesConfiguration/ContactRecordConfiguration.cs
@@ -13,7 +13,9 @@ internal class ContactRecordConfiguration : IEntityTypeConfiguration<ContactReco
             .ValueGeneratedNever();
 
         builder
-            .HasIndex(o => o.ContactUserId);
+            .HasIndex(o => o.ContactUserId)
+            .HasFilter("\"ContactUserId\" IS NOT NULL")
+            .IsUnique();
 
         // Many-to-many: ContactRecord <-> FloodReport
         builder

--- a/Database/Migrations/20260407091005_SetupContactModelConstraint.Designer.cs
+++ b/Database/Migrations/20260407091005_SetupContactModelConstraint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FloodOnlineReportingTool.Database.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FloodOnlineReportingTool.Database.Migrations
 {
     [DbContext(typeof(PublicDbContext))]
-    partial class PublicDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260407091005_SetupContactModelConstraint")]
+    partial class SetupContactModelConstraint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20260407091005_SetupContactModelConstraint.cs
+++ b/Database/Migrations/20260407091005_SetupContactModelConstraint.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FloodOnlineReportingTool.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class SetupContactModelConstraint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ContactRecords_ContactUserId",
+                schema: "fortpublic",
+                table: "ContactRecords");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ContactRecords_ContactUserId",
+                schema: "fortpublic",
+                table: "ContactRecords",
+                column: "ContactUserId",
+                unique: true,
+                filter: "\"ContactUserId\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ContactRecords_ContactUserId",
+                schema: "fortpublic",
+                table: "ContactRecords");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ContactRecords_ContactUserId",
+                schema: "fortpublic",
+                table: "ContactRecords",
+                column: "ContactUserId");
+        }
+    }
+}

--- a/Database/Models/Investigate/InvestigationDto.cs
+++ b/Database/Models/Investigate/InvestigationDto.cs
@@ -2,6 +2,8 @@
 
 public record InvestigationDto
 {
+    public Guid FloodReportId { get; init; }
+
     // Internal fields
     public Guid? WhenWaterEnteredKnownId { get; init; }
     public DateTimeOffset? FloodInternalUtc { get; init; }

--- a/Database/Repositories/FloodReportRepository.cs
+++ b/Database/Repositories/FloodReportRepository.cs
@@ -65,7 +65,10 @@ public class FloodReportRepository(
             .AsSplitQuery()
             .Where(cr => cr.ContactUserId == contactUserId)
             .SelectMany(cr => cr.FloodReports)
+            .DistinctBy(fr => fr.Id)
+            .IgnoreAutoIncludes()     // Might need to remove this if we actually want sources and areas flooded. 
             .Include(o => o.EligibilityCheck)
+            .Include(o => o.ContactRecords)
             .Include(o => o.Status)
             .OrderByDescending(cr => cr.CreatedUtc)
             .ToListAsync(ct);

--- a/Database/Repositories/FloodReportRepository.cs
+++ b/Database/Repositories/FloodReportRepository.cs
@@ -65,7 +65,6 @@ public class FloodReportRepository(
             .AsSplitQuery()
             .Where(cr => cr.ContactUserId == contactUserId)
             .SelectMany(cr => cr.FloodReports)
-            .DistinctBy(fr => fr.Id)
             .IgnoreAutoIncludes()     // Might need to remove this if we actually want sources and areas flooded. 
             .Include(o => o.EligibilityCheck)
             .Include(o => o.ContactRecords)

--- a/Database/Repositories/FloodReportRepository.cs
+++ b/Database/Repositories/FloodReportRepository.cs
@@ -65,8 +65,9 @@ public class FloodReportRepository(
             .AsSplitQuery()
             .Where(cr => cr.ContactUserId == contactUserId)
             .SelectMany(cr => cr.FloodReports)
-            .OrderByDescending(cr => cr.CreatedUtc)
+            .Include(o => o.EligibilityCheck)
             .Include(o => o.Status)
+            .OrderByDescending(cr => cr.CreatedUtc)
             .ToListAsync(ct);
     }
 

--- a/Database/Repositories/FloodReportRepository.cs
+++ b/Database/Repositories/FloodReportRepository.cs
@@ -152,19 +152,19 @@ public class FloodReportRepository(
             .FirstOrDefaultAsync(o => o.Reference == reference, ct);
     }
 
-    public async Task<(bool hasFloodReport, bool hasInvestigation, bool hasInvestigationStarted, DateTimeOffset? investigationCreatedUtc)> ReportedByUserBasicInformation(string userId, CancellationToken ct)
+    public async Task<(bool hasFloodReport, bool hasInvestigation, bool hasInvestigationStarted, DateTimeOffset? investigationCreatedUtc)> InvestigationBasicInformation(Guid FloodReportId, CancellationToken ct)
     {
-        logger.LogInformation("Getting flood report details by user.");
+        logger.LogInformation("Getting flood report details by id.");
 
         // In simple terms only 2 fields are needed, StatusId and Investigation.CreatedUtc
         // Calling the standard ReportedByUser method is not efficient as it loads all related tables
 
         await using var context = await contextFactory.CreateDbContextAsync(ct);
 
-        var result = await context.ContactRecords
+        var result = await context.FloodReports
             .AsNoTracking()
-            .Where(cr => cr.ContactUserId == userId)
-            .SelectMany(cr => cr.FloodReports)
+            .Where(cr => cr.Id == FloodReportId)
+            .Include(cr => cr.Investigation)
             .Select(o => new
             {
                 o.StatusId,

--- a/Database/Repositories/IFloodReportRepository.cs
+++ b/Database/Repositories/IFloodReportRepository.cs
@@ -41,7 +41,7 @@ public interface IFloodReportRepository
     /// <summary>
     /// Get basic flood report information for the given user
     /// </summary>
-    Task<(bool hasFloodReport, bool hasInvestigation, bool hasInvestigationStarted, DateTimeOffset? investigationCreatedUtc)> ReportedByUserBasicInformation(string userId, CancellationToken ct);
+    Task<(bool hasFloodReport, bool hasInvestigation, bool hasInvestigationStarted, DateTimeOffset? investigationCreatedUtc)> InvestigationBasicInformation(Guid FloodReportId, CancellationToken ct); 
 
     /// <summary>
     ///     <para>Create a new flood report.</para>

--- a/Database/Repositories/IInvestigationRepository.cs
+++ b/Database/Repositories/IInvestigationRepository.cs
@@ -12,7 +12,7 @@ public interface IInvestigationRepository
     /// <summary>
     /// Create the investigation for the given user, going via the flood report
     /// </summary>
-    Task<Investigation> CreateForUser(string userId, InvestigationDto dto, CancellationToken ct);
+    Task<Investigation> CreateForFloodReport(string userId, InvestigationDto dto, CancellationToken ct);
 
     /// <summary>
     /// Get basic investigation information for the given user. (no related records)

--- a/Database/Repositories/InvestigationRepository.cs
+++ b/Database/Repositories/InvestigationRepository.cs
@@ -20,12 +20,11 @@ public class InvestigationRepository(PublicDbContext context, IPublishEndpoint p
             .FirstOrDefaultAsync(o => o != null && o.Id == id, ct);
     }
 
-    public async Task<Investigation> CreateForUser(string userId, InvestigationDto investigationDto, CancellationToken ct)
+    public async Task<Investigation> CreateForFloodReport(string userId, InvestigationDto investigationDto, CancellationToken ct)
     {
-        var floodReport = await context.ContactRecords
+        var floodReport = await context.FloodReports
             .AsNoTracking()
-            .Where(cr => cr.ContactUserId == userId)
-            .SelectMany(cr => cr.FloodReports)
+            .Where(cr => cr.Id == investigationDto.FloodReportId)
             .FirstOrDefaultAsync(ct);
 
         if (floodReport == null)

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/Confirmation.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/Confirmation.razor
@@ -27,6 +27,12 @@
             <section id="what-happens-next">
                 <h2 class="govuk-heading-l">What happens next</h2>
 
+                <p>The responsible organisation that requested you complete the form will now be able to access the additional information you have provided. This will be used as part of the ongoing investigation work.</p>
+
+                <p>You can return the manage reports page to view this and any other reports allowing you to see any updates</p>
+
+                <GdsStartButton Href="@FloodReportPages.Overview.Url" Text="Manage an existing reports" />
+
             </section>
         }
     </Authorized>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/floodreport/investigation"
+﻿@page "/floodreport/investigation/{FloodReportId:guid}"
 @using Microsoft.AspNetCore.Components.Authorization
 
 <PageTitle>@Title</PageTitle>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/Index.razor.cs
@@ -1,15 +1,19 @@
-﻿using FloodOnlineReportingTool.Database.Repositories;
+﻿using FloodOnlineReportingTool.Database.Models.Investigate;
+using FloodOnlineReportingTool.Database.Repositories;
+using FloodOnlineReportingTool.Public.Models;
 using FloodOnlineReportingTool.Public.Models.Order;
 using GdsBlazorComponents;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using System.Security.Claims;
 
 namespace FloodOnlineReportingTool.Public.Components.Pages.FloodReport.Investigation;
 
 [Authorize]
 public partial class Index(
+    ProtectedSessionStorage protectedSessionStorage,
     IFloodReportRepository floodReportRepository
 ) : IPageOrder, IAsyncDisposable
 {
@@ -19,6 +23,9 @@ public partial class Index(
         GeneralPages.Home.ToGdsBreadcrumb(),
         FloodReportPages.Overview.ToGdsBreadcrumb(),
     ];
+
+    [Parameter]
+    public Guid FloodReportId { get; set; }
 
     [CascadingParameter]
     public Task<AuthenticationState>? AuthenticationState { get; set; }
@@ -45,13 +52,21 @@ public partial class Index(
 
     protected override async Task OnInitializedAsync()
     {
-        if (AuthenticationState is not null)
+        (_hasFloodReport, _hasInvestigation, _hasInvestigationStarted, _investigationCreatedUtc) = await floodReportRepository.InvestigationBasicInformation(FloodReportId, _cts.Token);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
         {
-            var authState = await AuthenticationState;
-            var userID = authState.User.Oid;
-            if (userID is not null)
+            if (_hasInvestigationStarted == false)
             {
-                (_hasFloodReport, _hasInvestigation, _hasInvestigationStarted, _investigationCreatedUtc) = await floodReportRepository.ReportedByUserBasicInformation(userID, _cts.Token);
+                //We start it here
+                InvestigationDto investigation = new InvestigationDto() with
+                {
+                    FloodReportId = FloodReportId
+                };
+                await protectedSessionStorage.SetAsync(SessionConstants.Investigation, investigation);
             }
         }
     }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/Summary.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/Summary.razor.cs
@@ -122,7 +122,7 @@ public partial class Summary(
         logger.LogDebug("Saving investigation information..");
         try
         {
-            await investigationRepository.CreateForUser(userId, dto, _cts.Token);
+            await investigationRepository.CreateForFloodReport(userId, dto, _cts.Token);
 
             // Clear the stored data
             await protectedSessionStorage.DeleteAsync(SessionConstants.Investigation);

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Details.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Details.razor
@@ -8,14 +8,13 @@
 
 <PageTitle>@FloodReportPages.Overview.Title</PageTitle>
 
-<GdsBreadcrumbs Items="@([GeneralPages.Home.ToGdsBreadcrumb()])" />
+<GdsBackLink Href="@PreviousPage.Url"></GdsBackLink>
 
 <AuthorizeView Policy="@PolicyNames.Admin">
     <Authorized>
         <h1 class="govuk-heading-xl">The users flood report</h1>
     </Authorized>
     <NotAuthorized>
-        @* <h1 class="govuk-heading-xl">Your flood report</h1> *@
     </NotAuthorized>
 </AuthorizeView>
 
@@ -33,6 +32,8 @@
             }
             else
             {
+                <!-- Do we even want this bit? -->
+
                 <div class="govuk-panel govuk-panel--confirmation">
                     <h1 class="govuk-panel__title">Record Status: @(_floodReport.Status?.Text ?? "Unknown status")</h1>
                     <div class="govuk-panel__body">
@@ -75,201 +76,226 @@
             }
         </NotAuthorized>
         <Authorized>
-            <div class="govuk-grid-row">
-                @if (_floodReport == null)
-                {
-                    <div class="govuk-grid-column-full">
-                        <GdsWarning Text="We cannot find your flood report." />
-                    </div>
-                }
-                else
-                {
-                    <div class="govuk-grid-column-full">
-                        @* <p class="govuk-body-l">
-                            <strong class="govuk-tag">@(_floodReport.Status?.Text ?? "Unknown status")</strong>
-                            Flood reference <strong>@_floodReport.Reference</strong>
-                        </p>
-
-                        <p>Created on @_floodReport.CreatedUtc.GdsReadable()</p> *@
-
-                        @if (_accessHasExpired)
+            <div class="govuk-tabs" data-module="govuk-tabs">
+                <h2 class="govuk-tabs__title">
+                    Contents
+                </h2>
+                <ul class="govuk-tabs__list">
+                    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                        <a class="govuk-tabs__tab" href="#overview">
+                            Overview
+                        </a>
+                    </li>
+                    <li class="govuk-tabs__list-item">
+                        <a class="govuk-tabs__tab" href="#eligibility-form">
+                            Eligibility form
+                        </a>
+                    </li>
+                    <li class="govuk-tabs__list-item">
+                        <a class="govuk-tabs__tab" href="#investigation-form">
+                            Investigation form
+                        </a>
+                    </li>
+                </ul>
+                <div class="govuk-tabs__panel" id="overview">
+                    <div class="govuk-grid-row">
+                        @if (_floodReport == null)
                         {
-                            <GdsWarning Text="Your access to this flood report has expired" />
+                            <div class="govuk-grid-column-full">
+                                <GdsWarning Text="We cannot find your flood report." />
+                            </div>
                         }
                         else
                         {
-                            @* <p>Your access to this flood report will expire in @_accessTimeLeft.GdsReadable()</p> *@
+                            <div class="govuk-grid-column-full">
+                                <p class="govuk-body-l">
+                                    <strong class="govuk-tag">@(_floodReport.Status?.Text ?? "Unknown status")</strong>
+                                    Flood reference <strong>@_floodReport.Reference</strong>
+                                </p>
 
-                            @* @if (_floodReport.StatusId == RecordStatusIds.ActionNeeded)
-                            {
-                                <h2 class="govuk-heading-l">Tell us more</h2>
-                                <p>There is currently an ongoing investigation.</p>
-                                <p>We need some more information from you to help us complete the investigation.</p>
-                                <p>This will include details about:</p>
-                                <ul>
-                                    <li>Information about how and when water entered your property</li>
-                                    <li>Flood depths</li>
-                                    <li>Warnings you received</li>
-                                    <li>Any help you were provided with</li>
-                                    <li>More information about the flood water itself</li>
-                                </ul>
-                                <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button govuk-button--start" data-module="govuk-button" href="@InvestigationPages.FirstPage.Url">
-                                    Start now
-                                    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-                                        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-                                    </svg>
-                                </a>
-                            } *@
+                                @if (_accessHasExpired)
+                                {
+                                    <GdsWarning Text="Your access to this flood report has expired" />
+                                }
+                                else
+                                {
+                                    <p>Created on @_floodReport.CreatedUtc.GdsReadable() and your access to this flood report will expire in @_accessTimeLeft.GdsReadable()</p>
+                                }
+                            </div>
 
-                            @if (_floodReport.InvestigationId != null)
-                            {
-                                <h2 class="govuk-heading-l">Investigation</h2>
-                                <p>An investigation has been completed for this flood report.</p>
-                            }
+                            <section id="eligibility-results">
+                                <div class="govuk-grid-column-full">
+                                    <h2 class="govuk-heading-l">Eligibility results</h2>
 
-                            @* @if (_floodReport.EligibilityCheckId != null)
-                            {
-                                <h2 class="govuk-heading-l">Update your records</h2>
-                                <p>You can provide updates to records you have already submitted.</p>
-                                <GdsWarning Text="Coming soon..." />
-                                <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@($"{FloodReportPages.Update.Url}/{_floodReport.EligibilityCheckId}")">@FloodReportPages.Update.Title</a>
-                            } *@
+                                    @if (_isEmergencyResponse)
+                                    {
+                                        <p>This service does not trigger an emergency response please ring 999 and ask for the relevant service.</p>
+                                    }
+
+                                    @switch (_floodInvestigation)
+                                    {
+                                        case EligibilityOptions.Eligible:
+                                            <p>Your record is eligible for a property level flood investigation. Please complete a full flood report so the relevant organisations can complete this investigation.</p>
+                                            break;
+
+                                        case EligibilityOptions.Conditional:
+                                            <p>Because your property was flooded internally you may be eligible for additional support from you lead local flood authority. Eligibility is not automatic but if you are signed up for updates on this record the relevant organisation can let you know if they believe you are eligible.</p>
+                                            <p>If you want to discuss this further with the relevant organisations, use the reference number above to allow them to see the details of this flood event and this may help you to get a decision.</p>
+                                            break;
+
+                                        case EligibilityOptions.None:
+                                            <p>You may be eligible to apply for help installing property level protection for your property. Use the link provided to submit an application.</p>
+                                            break;
+                                    }
+
+                                    @switch (_grantApplication)
+                                    {
+                                        case EligibilityOptions.Eligible:
+                                            <p>You have successfully applied for a grant in relation to this flood event.</p>
+                                            <p>For further details, refer to whichever system you used to apply for the grant.</p>
+                                            break;
+
+                                        case EligibilityOptions.Conditional:
+                                            <p>You may be eligible to apply for a grant. Use the link provided to submit an application.</p>
+                                            break;
+                                    }
+
+                                    @switch (_propertyProtection)
+                                    {
+                                        case EligibilityOptions.Eligible:
+                                            <p>You have successfully applied for help installing property level protection for your property.</p>
+                                            break;
+
+                                        case EligibilityOptions.Conditional:
+                                            <p>You may be eligible to apply for help installing property level protection for your property. Use the link provided to submit an application.</p>
+                                            break;
+                                    }
+
+                                    @switch (_section19)
+                                    {
+                                        case EligibilityOptions.Eligible:
+                                            <p>The lead local flood authority responsible for your property has begun a section 19 flood investigation. To help with this process you can complete a full flood report to provide further information about this flood event. The details you provide will assist them in their investigations.</p>
+                                            break;
+
+                                        case EligibilityOptions.Completed:
+                                            <p>
+                                                The lead local flood authority responsible for your property has completed a section 19 flood investigation for this flood event.
+                                                @if (string.IsNullOrEmpty(_section19Url))
+                                                {
+                                                    <span>The report is published and can be found by contacting the lead local flood authority.</span>
+                                                }
+                                                else
+                                                {
+                                                    <span>The report is published and can be found at <a href="@_section19Url" target="_blank" class="govuk-link">@_section19Url</a>.</span>
+                                                }
+                                            </p>
+                                            break;
+                                    }
+                                </div>
+                            </section>
+
+                            <section id="investigation-actions">
+                                <div class="govuk-grid-column-full">
+                                    @if (_floodReport.StatusId == RecordStatusIds.ActionNeeded)
+                                    {
+                                        <h2 class="govuk-heading-l">Tell us more</h2>
+                                        <p>There is currently an ongoing investigation.</p>
+                                        <p>We need some more information from you to help us complete the investigation.</p>
+                                        <p>This will include details about:</p>
+                                        <ul>
+                                            <li>Information about how and when water entered your property</li>
+                                            <li>Flood depths</li>
+                                            <li>Warnings you received</li>
+                                            <li>Any help you were provided with</li>
+                                            <li>More information about the flood water itself</li>
+                                        </ul>
+                                        <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button govuk-button--start" data-module="govuk-button" href="@InvestigationPages.FirstPage.Url">
+                                            Start now
+                                            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+                                                <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+                                            </svg>
+                                        </a>
+                                    }
+                                </div>
+                            </section>
+
+                            <section id="subscription-actions">
+                                <div class="govuk-grid-column-full">
+                                    @if (!_accessHasExpired)
+                                    {
+                                        <h2 class="govuk-heading-l">Keep informed</h2>
+
+                                        @if (_floodReport.ContactRecords.Count > 0)
+                                        {
+                                            <p>Change your contact details if you would like to:</p>
+                                            <ul class="govuk-list govuk-list--bullet">
+                                                <li>receive updates</li>
+                                                <li>check the progress of your application</li>
+                                                <li>reset your login details</li>
+                                                <li>update your contact information</li>
+                                                <li>provide temporary contact information</li>
+                                            </ul>
+                                        }
+                                        else
+                                        {
+                                            <p>Give us your contact details if you would like to:</p>
+                                            <ul class="govuk-list govuk-list--bullet">
+                                                <li>receive updates</li>
+                                                <li>check the progress of your application</li>
+                                                <li>reset your login details</li>
+                                            </ul>
+                                        }
+
+                                        <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@ContactPages.Summary.Url">@ContactPages.Summary.Title</a>
+                                    }
+                                </div>
+                            </section>
                         }
                     </div>
+                    @* <section id="responsible-organisations">
+                        <h2 class="govuk-heading-l">Responsible organisations</h2>
 
-                    @* @if (!_accessHasExpired)
+                        @if (_leadLocalFloodAuthorities.Any())
+                        {
+                            <div class="govuk-inset-text">
+                                @foreach (var org in _leadLocalFloodAuthorities)
+                                {
+                                    @((MarkupString)org.Description.Replace("{{orgLogo}}", org.Logo.ToString()))
+                                }
+                            </div>
+                        }
+
+                        @if (_otherFloodAuthorities.Any())
+                        {
+                            <p>Other responsible organisations include:</p>
+                            @foreach (var org in _otherFloodAuthorities)
+                            {
+                                <p>@((MarkupString)org.Description.Replace("{{orgLogo}}", org.Logo.ToString()))</p>
+                            }
+                        }
+                    </section> *@
+                </div>
+                <div class="govuk-tabs__panel" id="eligibility-form">
+                    <h2 class="govuk-heading-l">View report</h2>
+                    <p class="govuk-body-l">Details of your flood report can be seen below.</p>
+                    <p>Your access to this flood report will expire in @_accessTimeLeft.GdsReadable()</p>
+                    @if (_floodReport.EligibilityCheck is not null)
                     {
-                        <div class="govuk-grid-column-full">
-                            <h2 class="govuk-heading-l">Keep informed</h2>
-
-                            @if (_floodReport.ContactRecords.Count > 0)
-                            {
-                                <p>Change your contact details if you would like to:</p>
-                                <ul class="govuk-list govuk-list--bullet">
-                                    <li>receive updates</li>
-                                    <li>check the progress of your application</li>
-                                    <li>reset your login details</li>
-                                    <li>update your contact information</li>
-                                    <li>provide temporary contact information</li>
-                                </ul>
-                            }
-                            else
-                            {
-                                <p>Give us your contact details if you would like to:</p>
-                                <ul class="govuk-list govuk-list--bullet">
-                                    <li>receive updates</li>
-                                    <li>check the progress of your application</li>
-                                    <li>reset your login details</li>
-                                </ul>
-                            }
-
-                            <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@ContactPages.Summary.Url">@ContactPages.Summary.Title</a>
-                        </div>
-                    } *@
-                }
-            </div>
-
-            @* <section id="eligibility-results">
-                <h2 class="govuk-heading-l">Eligibility results</h2>
-
-                @if (_isEmergencyResponse)
-                {
-                    <p>This service does not trigger an emergency response please ring 999 and ask for the relevant service.</p>
-                }
-
-                @switch (_floodInvestigation)
-                {
-                    case EligibilityOptions.Eligible:
-                        <p>Your record is eligible for a property level flood investigation. Please complete a full flood report so the relevant organisations can complete this investigation.</p>
-                        break;
-
-                    case EligibilityOptions.Conditional:
-                        <p>Because your property was flooded internally you may be eligible for additional support from you lead local flood authority. Eligibility is not automatic but if you are signed up for updates on this record the relevant organisation can let you know if they believe you are eligible.</p>
-                        <p>If you want to discuss this further with the relevant organisations, use the reference number above to allow them to see the details of this flood event and this may help you to get a decision.</p>
-                        break;
-
-                    case EligibilityOptions.None:
-                        <p>You may be eligible to apply for help installing property level protection for your property. Use the link provided to submit an application.</p>
-                        break;
-                }
-
-                @switch (_grantApplication)
-                {
-                    case EligibilityOptions.Eligible:
-                        <p>You have successfully applied for a grant in relation to this flood event.</p>
-                        <p>For further details, refer to whichever system you used to apply for the grant.</p>
-                        break;
-
-                    case EligibilityOptions.Conditional:
-                        <p>You may be eligible to apply for a grant. Use the link provided to submit an application.</p>
-                        break;
-                }
-
-                @switch (_propertyProtection)
-                {
-                    case EligibilityOptions.Eligible:
-                        <p>You have successfully applied for help installing property level protection for your property.</p>
-                        break;
-
-                    case EligibilityOptions.Conditional:
-                        <p>You may be eligible to apply for help installing property level protection for your property. Use the link provided to submit an application.</p>
-                        break;
-                }
-
-                @switch (_section19)
-                {
-                    case EligibilityOptions.Eligible:
-                        <p>The lead local flood authority responsible for your property has begun a section 19 flood investigation. To help with this process you can complete a full flood report to provide further information about this flood event. The details you provide will assist them in their investigations.</p>
-                        break;
-
-                    case EligibilityOptions.Completed:
-                        <p>
-                            The lead local flood authority responsible for your property has completed a section 19 flood investigation for this flood event.
-                            @if (string.IsNullOrEmpty(_section19Url))
-                            {
-                                <span>The report is published and can be found by contacting the lead local flood authority.</span>
-                            }
-                            else
-                            {
-                                <span>The report is published and can be found at <a href="@_section19Url" target="_blank" class="govuk-link">@_section19Url</a>.</span>
-                            }
-                        </p>
-                        break;
-                }
-            </section> *@
-
-            <section id="eligibility-report">
-                <h2 class="govuk-heading-l">View report</h2>
-                <p class="govuk-body-l">Details of your flood report can be seen below.</p>
-                <p>Your access to this flood report will expire in @_accessTimeLeft.GdsReadable()</p>
-                @if (_floodReport.EligibilityCheck is not null)
-                {
-                    <EligibilityCheckSummary Entity="@_floodReport.EligibilityCheck" />
-                }
-            </section>
-
-            @* <section id="responsible-organisations">
-            <h2 class="govuk-heading-l">Responsible organisations</h2>
-
-            @if (_leadLocalFloodAuthorities.Any())
-            {
-                <div class="govuk-inset-text">
-                    @foreach (var org in _leadLocalFloodAuthorities)
-                    {
-                        @((MarkupString)org.Description.Replace("{{orgLogo}}", org.Logo.ToString()))
+                        <EligibilityCheckSummary Entity="@_floodReport.EligibilityCheck" />
                     }
                 </div>
-            }
-
-            @if (_otherFloodAuthorities.Any())
-            {
-                <p>Other responsible organisations include:</p>
-                @foreach (var org in _otherFloodAuthorities)
-                {
-                    <p>@((MarkupString)org.Description.Replace("{{orgLogo}}", org.Logo.ToString()))</p>
-                }
-            }
-        </section> *@
+                <div class="govuk-tabs__panel" id="investigation-form">
+                    @if (_floodReport.InvestigationId != null)
+                    {
+                        <h2 class="govuk-heading-l">Detailed investigation</h2>
+                        <p>An investigation has been completed for this flood report.</p>
+                    } else
+                    {
+                        <h2 class="govuk-heading-l">Detailed investigation</h2>
+                        <p>Investigation form is not yet available for this report.</p>
+                    }
+                </div>
+            </div>
         </Authorized>
     </AuthorizeView>
 }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Details.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Details.razor.cs
@@ -1,5 +1,6 @@
 ﻿using FloodOnlineReportingTool.Database.Models.Eligibility;
 using FloodOnlineReportingTool.Database.Repositories;
+using FloodOnlineReportingTool.Public.Models.Order;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using System.Security.Claims;
@@ -18,6 +19,8 @@ public partial class Details(
 
     [Parameter]
     public string? FloodReportReference { get; set; }
+
+    private PageInfo PreviousPage => FloodReportPages.Overview;
 
     private readonly CancellationTokenSource _cts = new();
     private bool _isLoading = true;

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
@@ -29,7 +29,7 @@
         </NotAuthorized>
         <Authorized>
             <div class="govuk-grid-row">
-                @if (_floodReport.Count == 0)
+                @if (_floodReports.Count == 0)
                 {
                     <div class="govuk-grid-column-full">
                         <GdsWarning Text="We cannot find your flood reports." />
@@ -39,10 +39,10 @@
                 {
                     <div class="govuk-grid-column-full">
                         <p class="govuk-body-l">
-                            This page will help you to find and manage your flood reports if you have reported more than once. Please use the `View report` option to find out more about the status of a specific report. 
+                            This page will help you to find and manage your flood reports if you have reported more than once. Please use the "View report" option to find out more about the status of a specific report. 
                         </p>
 
-                        <GdsTable T="Database.Models.Flood.FloodReport" Items="@_floodReport" Caption="Your flood reports" CaptionSize="GdsTableCaptionSize.Large" Density="GdsTableDensity.SmallTextUntilTablet">
+                        <GdsTable T="Database.Models.Flood.FloodReport" Items="@_floodReports" Caption="Your flood reports" CaptionSize="GdsTableCaptionSize.Large" Density="GdsTableDensity.SmallTextUntilTablet">
                             <HeaderContent>
                                 <GdsTableTh>Reference</GdsTableTh>
                                 <GdsTableTh>Status</GdsTableTh>
@@ -68,7 +68,7 @@
                                     }
                                 </GdsTableTd>
                                 <GdsTableTd Value="@item.CreatedUtc.GdsReadable()" />
-                                <GdsTableTd Value="item.EligibilityCheck?.LocationDesc" />
+                                <GdsTableTd Value="@item.EligibilityCheck?.LocationDesc" />
                                 <GdsTableTd Value="@item.EligibilityCheck?.ImpactStart.GdsReadable()" />
                                 <GdsTableTd>
                                     <div class="govuk-button-group">
@@ -93,7 +93,7 @@
 
                         <!-- Contact details are per user so this should be the same in all contexts -->
                         <!-- If using a magic link there will only be one report so skip this page entirely! -->
-                        @if (_floodReport.First().ContactRecords.Count > 0)
+                        @if (_floodReports.First().ContactRecords.Count > 0)
                         {
                             <p>Change your contact details if you would like to:</p>
                             <ul class="govuk-list govuk-list--bullet">

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
@@ -13,7 +13,7 @@
         <h1 class="govuk-heading-xl">The users flood report</h1>
     </Authorized>
     <NotAuthorized>
-        @* <h1 class="govuk-heading-xl">Your flood report</h1> *@
+
     </NotAuthorized>
 </AuthorizeView>
 
@@ -23,244 +23,101 @@
 {
     <AuthorizeView>
         <NotAuthorized>
-            @if (_floodReport == null)
-            {
-                <div class="govuk-grid-column-full">
-                    <GdsWarning Text="We cannot find your flood report." />
-                </div>
-            }
-            else
-            {
-                <div class="govuk-panel govuk-panel--confirmation">
-                    <h1 class="govuk-panel__title">Record Status: @(_floodReport.Status?.Text ?? "Unknown status")</h1>
-                    <div class="govuk-panel__body">
-                        Flood reference <strong>@_floodReport.Reference</strong>
-                    </div>
-                </div>
-
-                @if (_accessHasExpired)
-                {
-                    <GdsWarning Text="Your access to this flood report has expired" />
-                }
-                else
-                {
-                    <p>Please make a note of your flood reference but note you are not able to update or view your record online as you are not logged in.</p>
-                    <p>You will receive update notifications about your report by email if you provided one.</p>
-                }
-
-                @if (_floodReport.StatusId == RecordStatusIds.ActionNeeded)
-                {
-                    <h2 class="govuk-heading-l">Tell us more</h2>
-                    <p>There is currently an ongoing investigation.</p>
-                    <p>We need some more information from you to help us complete the investigation.</p>
-                    <p>This will include details about:</p>
-                    <ul>
-                        <li>Information about how and when water entered your property</li>
-                        <li>Flood depths</li>
-                        <li>Warnings you received</li>
-                        <li>Any help you were provided with</li>
-                        <li>More information about the flood water itself</li>
-                    </ul>
-                    <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button govuk-button--start" data-module="govuk-button" href="@InvestigationPages.FirstPage.Url">
-                        Start now
-                        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-                            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-                        </svg>
-                    </a>
-                }
-
-                <p>Created on @_floodReport.CreatedUtc.GdsReadable()</p>
-            }
+            <div class="govuk-grid-column-full">
+                <GdsWarning Text="We cannot find your flood reports." />
+            </div>
         </NotAuthorized>
         <Authorized>
             <div class="govuk-grid-row">
-                @if (_floodReport == null)
+                @if (_floodReport.Count == 0)
                 {
                     <div class="govuk-grid-column-full">
-                        <GdsWarning Text="We cannot find your flood report." />
+                        <GdsWarning Text="We cannot find your flood reports." />
                     </div>
                 }
                 else
                 {
                     <div class="govuk-grid-column-full">
                         <p class="govuk-body-l">
-                            <strong class="govuk-tag">@(_floodReport.Status?.Text ?? "Unknown status")</strong>
-                            Flood reference <strong>@_floodReport.Reference</strong>
+                            This page will help you to find and manage your flood reports if you have reported more than once. Please use the `View report` option to find out more about the status of a specific report. 
                         </p>
 
-                        <p>Created on @_floodReport.CreatedUtc.GdsReadable()</p>
+                        <GdsTable T="Database.Models.Flood.FloodReport" Items="@_floodReport" Caption="Your flood reports" CaptionSize="GdsTableCaptionSize.Large" Density="GdsTableDensity.SmallTextUntilTablet">
+                            <HeaderContent>
+                                <GdsTableTh>Reference</GdsTableTh>
+                                <GdsTableTh>Status</GdsTableTh>
+                                <GdsTableTh>Date reported</GdsTableTh>
+                                <GdsTableTh>Address</GdsTableTh>
+                                <GdsTableTh>Flooding date</GdsTableTh>
+                                <GdsTableTh>Options</GdsTableTh>
+                            </HeaderContent>
+                            <RowTemplate Context="item">
+                                <GdsTableTd Value="@item.Reference" />
+                                <GdsTableTd>
+                                    @if (item.StatusId == RecordStatusIds.ActionNeeded)
+                                    {
+                                        <GdsTag Colour="GdsTagColour.Yellow" Text="@item.Status?.Text" />
+                                    }
+                                    else if (item.StatusId == RecordStatusIds.MarkedForDeletion)
+                                    {
+                                        <GdsTag Colour="GdsTagColour.Red" Text="@item.Status?.Text" />
+                                    }
+                                    else
+                                    {
+                                        <GdsTag Colour="GdsTagColour.Green" Text="@(item.Status?.Text?? "Unknown status")" />
+                                    }
+                                </GdsTableTd>
+                                <GdsTableTd Value="@item.CreatedUtc.GdsReadable()" />
+                                <GdsTableTd Value="item.EligibilityCheck?.LocationDesc" />
+                                <GdsTableTd Value="@item.EligibilityCheck?.ImpactStart.GdsReadable()" />
+                                <GdsTableTd>
+                                    <div class="govuk-button-group">
+                                        @if (item.StatusId == RecordStatusIds.ActionNeeded)
+                                        {
+                                            <GdsButton IsSubmit="false" Text="Tell us more" OnClick="@(() => PerformAction(item.Id))" />
+                                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Overview.Title" AdditionalCssClasses="govuk-button--secondary" OnClick="@(() => ViewReport(item.Id))" />
+                                        } else
+                                        {
+                                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Overview.Title" OnClick="@(() => ViewReport(item.Id))" />
+                                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Update.Title" OnClick="@(() => UpdateReport(item.EligibilityCheckId))" />
+                                        }
+                                        
+                                    </div>
+                                </GdsTableTd>
+                            </RowTemplate>
+                        </GdsTable>
+                    </div>
 
-                        @if (_accessHasExpired)
+                    <div class="govuk-grid-column-full">
+                        <h2 class="govuk-heading-l">Keep informed</h2>
+
+                        <!-- Contact details are per user so this should be the same in all contexts -->
+                        <!-- If using a magic link there will only be one report so skip this page entirely! -->
+                        @if (_floodReport.First().ContactRecords.Count > 0)
                         {
-                            <GdsWarning Text="Your access to this flood report has expired" />
+                            <p>Change your contact details if you would like to:</p>
+                            <ul class="govuk-list govuk-list--bullet">
+                                <li>receive updates</li>
+                                <li>check the progress of your application</li>
+                                <li>reset your login details</li>
+                                <li>update your contact information</li>
+                                <li>provide temporary contact information</li>
+                            </ul>
                         }
                         else
                         {
-                            <p>Your access to this flood report will expire in @_accessTimeLeft.GdsReadable()</p>
-
-                            @if (_floodReport.StatusId == RecordStatusIds.ActionNeeded)
-                            {
-                                <h2 class="govuk-heading-l">Tell us more</h2>
-                                <p>There is currently an ongoing investigation.</p>
-                                <p>We need some more information from you to help us complete the investigation.</p>
-                                <p>This will include details about:</p>
-                                <ul>
-                                    <li>Information about how and when water entered your property</li>
-                                    <li>Flood depths</li>
-                                    <li>Warnings you received</li>
-                                    <li>Any help you were provided with</li>
-                                    <li>More information about the flood water itself</li>
-                                </ul>
-                                <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button govuk-button--start" data-module="govuk-button" href="@InvestigationPages.FirstPage.Url">
-                                    Start now
-                                    <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-                                        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-                                    </svg>
-                                </a>
-                            }
-
-                            @if (_floodReport.InvestigationId != null)
-                            {
-                                <h2 class="govuk-heading-l">Investigation</h2>
-                                <p>An investigation has been completed for this flood report.</p>
-                            }
-
-                            @if (_floodReport.EligibilityCheckId != null)
-                            {
-                                <h2 class="govuk-heading-l">Manage your reports</h2>
-                                <p>You can view or provide updates to reports you have already submitted.</p>
-                                <GdsWarning Text="Coming soon..." />
-                                <div class="govuk-button-group">
-                                    <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@($"{FloodReportPages.Overview.Url}/{_floodReport.Id}")">@FloodReportPages.Overview.Title</a>
-                                    <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@($"{FloodReportPages.Update.Url}/{_floodReport.EligibilityCheckId}")">@FloodReportPages.Update.Title</a>
-                                </div>
-                            }
+                            <p>Give us your contact details if you would like to:</p>
+                            <ul class="govuk-list govuk-list--bullet">
+                                <li>receive updates</li>
+                                <li>check the progress of your application</li>
+                                <li>reset your login details</li>
+                            </ul>
                         }
+
+                        <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@ContactPages.Summary.Url">@ContactPages.Summary.Title</a>
                     </div>
-
-                    @if (!_accessHasExpired)
-                    {
-                        <div class="govuk-grid-column-full">
-                            <h2 class="govuk-heading-l">Keep informed</h2>
-
-                            @if (_floodReport.ContactRecords.Count > 0)
-                            {
-                                <p>Change your contact details if you would like to:</p>
-                                <ul class="govuk-list govuk-list--bullet">
-                                    <li>receive updates</li>
-                                    <li>check the progress of your application</li>
-                                    <li>reset your login details</li>
-                                    <li>update your contact information</li>
-                                    <li>provide temporary contact information</li>
-                                </ul>
-                            }
-                            else
-                            {
-                                <p>Give us your contact details if you would like to:</p>
-                                <ul class="govuk-list govuk-list--bullet">
-                                    <li>receive updates</li>
-                                    <li>check the progress of your application</li>
-                                    <li>reset your login details</li>
-                                </ul>
-                            }
-
-                            <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@ContactPages.Summary.Url">@ContactPages.Summary.Title</a>
-                        </div>
-                    }
                 }
             </div>
-
-            <section id="eligibility-results">
-                <h2 class="govuk-heading-l">Eligibility results</h2>
-
-                @if (_isEmergencyResponse)
-                {
-                    <p>This service does not trigger an emergency response please ring 999 and ask for the relevant service.</p>
-                }
-
-                @switch (_floodInvestigation)
-                {
-                    case EligibilityOptions.Eligible:
-                        <p>Your record is eligible for a property level flood investigation. Please complete a full flood report so the relevant organisations can complete this investigation.</p>
-                        break;
-
-                    case EligibilityOptions.Conditional:
-                        <p>Because your property was flooded internally you may be eligible for additional support from you lead local flood authority. Eligibility is not automatic but if you are signed up for updates on this record the relevant organisation can let you know if they believe you are eligible.</p>
-                        <p>If you want to discuss this further with the relevant organisations, use the reference number above to allow them to see the details of this flood event and this may help you to get a decision.</p>
-                        break;
-
-                    case EligibilityOptions.None:
-                        <p>You may be eligible to apply for help installing property level protection for your property. Use the link provided to submit an application.</p>
-                        break;
-                }
-
-                @switch (_grantApplication)
-                {
-                    case EligibilityOptions.Eligible:
-                        <p>You have successfully applied for a grant in relation to this flood event.</p>
-                        <p>For further details, refer to whichever system you used to apply for the grant.</p>
-                        break;
-
-                    case EligibilityOptions.Conditional:
-                        <p>You may be eligible to apply for a grant. Use the link provided to submit an application.</p>
-                        break;
-                }
-
-                @switch (_propertyProtection)
-                {
-                    case EligibilityOptions.Eligible:
-                        <p>You have successfully applied for help installing property level protection for your property.</p>
-                        break;
-
-                    case EligibilityOptions.Conditional:
-                        <p>You may be eligible to apply for help installing property level protection for your property. Use the link provided to submit an application.</p>
-                        break;
-                }
-
-                @switch (_section19)
-                {
-                    case EligibilityOptions.Eligible:
-                        <p>The lead local flood authority responsible for your property has begun a section 19 flood investigation. To help with this process you can complete a full flood report to provide further information about this flood event. The details you provide will assist them in their investigations.</p>
-                        break;
-
-                    case EligibilityOptions.Completed:
-                        <p>
-                            The lead local flood authority responsible for your property has completed a section 19 flood investigation for this flood event.
-                            @if (string.IsNullOrEmpty(_section19Url))
-                            {
-                                <span>The report is published and can be found by contacting the lead local flood authority.</span>
-                            }
-                            else
-                            {
-                                <span>The report is published and can be found at <a href="@_section19Url" target="_blank" class="govuk-link">@_section19Url</a>.</span>
-                            }
-                        </p>
-                        break;
-                }
-            </section>
-
-            @* <section id="responsible-organisations">
-            <h2 class="govuk-heading-l">Responsible organisations</h2>
-
-            @if (_leadLocalFloodAuthorities.Any())
-            {
-                <div class="govuk-inset-text">
-                    @foreach (var org in _leadLocalFloodAuthorities)
-                    {
-                        @((MarkupString)org.Description.Replace("{{orgLogo}}", org.Logo.ToString()))
-                    }
-                </div>
-            }
-
-            @if (_otherFloodAuthorities.Any())
-            {
-                <p>Other responsible organisations include:</p>
-                @foreach (var org in _otherFloodAuthorities)
-                {
-                    <p>@((MarkupString)org.Description.Replace("{{orgLogo}}", org.Logo.ToString()))</p>
-                }
-            }
-        </section> *@
         </Authorized>
     </AuthorizeView>
 }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
@@ -71,16 +71,16 @@ public partial class Index(
                 _isLoading = false;
                 return;
             }
-            _floodReport.Add((Database.Models.Flood.FloodReport)localReport);
+            _floodReports.Add((Database.Models.Flood.FloodReport)localReport);
         }
         else
         {
-            _floodReport = [.. await floodReportRepository.AllReportedByContact(userId, _cts.Token)];
+            _floodReports = [.. await floodReportRepository.AllReportedByContact(userId, _cts.Token)];
         }
 
-        if (_floodReport.Count > 0)
+        if (_floodReports.Count > 0)
         {
-            //var result = await floodReportRepository.CalculateEligibilityWithReference(_floodReport.Reference, _cts.Token);
+            //var result = await floodReportRepository.CalculateEligibilityWithReference(_floodReports.Reference, _cts.Token);
 
             ////_leadLocalFloodAuthorities = [.. result.ResponsibleOrganisations.Where(o => o.FloodAuthorityId == FloodAuthorityIds.LeadLocalFloodAuthority)];
             ////_otherFloodAuthorities = [.. result.ResponsibleOrganisations.Where(o => o.FloodAuthorityId != FloodAuthorityIds.LeadLocalFloodAuthority)];

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
@@ -5,12 +5,14 @@ using FloodOnlineReportingTool.Public.Services;
 using GdsBlazorComponents;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using NetTopologySuite.Index.HPRtree;
 using System.Security.Claims;
 
 namespace FloodOnlineReportingTool.Public.Components.Pages.FloodReport.Overview;
 
 public partial class Index(
     IFloodReportRepository floodReportRepository,
+    NavigationManager navigationManager,
     SessionStateService scopedSessionStorage
 ) : IPageOrder, IAsyncDisposable
 {
@@ -23,7 +25,7 @@ public partial class Index(
 
     private readonly CancellationTokenSource _cts = new();
     private bool _isLoading = true;
-    private Database.Models.Flood.FloodReport? _floodReport;
+    private IList<Database.Models.Flood.FloodReport> _floodReport = [];
     private bool _accessHasExpired = true;
     private TimeSpan _accessTimeLeft;
 
@@ -53,53 +55,77 @@ public partial class Index(
         GC.SuppressFinalize(this);
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    protected override async Task OnParametersSetAsync()
     {
-        if (firstRender)
+        string? userId = null;
+        if (AuthenticationState is not null)
         {
-            string? userId = null;
-            if (AuthenticationState is not null)
+            var authState = await AuthenticationState;
+            userId = authState.User.Oid;
+        }
+        if (userId is null)
+        {
+            var floodReportId = await scopedSessionStorage.GetFloodReportId();
+            var localReport = await floodReportRepository.GetById(floodReportId, _cts.Token);
+            if (localReport is null)
             {
-                var authState = await AuthenticationState;
-                userId = authState.User.Oid;
+                return;
             }
-            if (userId is null)
-            {
-                var floodReportId = await scopedSessionStorage.GetFloodReportId();
-                _floodReport = await floodReportRepository.GetById(floodReportId, _cts.Token);
-            }
-            else
-            {
-                // TODO: Work out what to do when the user has reported multiple floods
-                var floodReports = await floodReportRepository.AllReportedByContact(userId, _cts.Token);
-                _floodReport = floodReports.OrderByDescending(o => o.CreatedUtc).FirstOrDefault();
-            }
+            _floodReport.Add((Database.Models.Flood.FloodReport)localReport);
+        }
+        else
+        {
+            _floodReport = [.. await floodReportRepository.AllReportedByContact(userId, _cts.Token)];
+        }
 
-            if (_floodReport is not null)
-            {
-                var result = await floodReportRepository.CalculateEligibilityWithReference(_floodReport.Reference, _cts.Token);
+        if (_floodReport.Count > 0)
+        {
+            //var result = await floodReportRepository.CalculateEligibilityWithReference(_floodReport.Reference, _cts.Token);
 
-                //_leadLocalFloodAuthorities = [.. result.ResponsibleOrganisations.Where(o => o.FloodAuthorityId == FloodAuthorityIds.LeadLocalFloodAuthority)];
-                //_otherFloodAuthorities = [.. result.ResponsibleOrganisations.Where(o => o.FloodAuthorityId != FloodAuthorityIds.LeadLocalFloodAuthority)];
+            ////_leadLocalFloodAuthorities = [.. result.ResponsibleOrganisations.Where(o => o.FloodAuthorityId == FloodAuthorityIds.LeadLocalFloodAuthority)];
+            ////_otherFloodAuthorities = [.. result.ResponsibleOrganisations.Where(o => o.FloodAuthorityId != FloodAuthorityIds.LeadLocalFloodAuthority)];
 
-                // These don't have any logic yet in the repository
-                _floodInvestigation = result.FloodInvestigation;
-                _isEmergencyResponse = result.IsEmergencyResponse;
-                _section19Url = result.Section19Url;
-                _section19 = result.Section19;
-                _propertyProtection = result.PropertyProtection;
-                _grantApplication = result.GrantApplication;
+            //// These don't have any logic yet in the repository
+            //_floodInvestigation = result.FloodInvestigation;
+            //_isEmergencyResponse = result.IsEmergencyResponse;
+            //_section19Url = result.Section19Url;
+            //_section19 = result.Section19;
+            //_propertyProtection = result.PropertyProtection;
+            //_grantApplication = result.GrantApplication;
 
-                // Check if the users access has expired
-                if (_floodReport.ReportOwnerAccessUntil != null)
-                {
-                    _accessTimeLeft = _floodReport.ReportOwnerAccessUntil.Value - DateTimeOffset.UtcNow;
-                    _accessHasExpired = _accessTimeLeft <= TimeSpan.Zero;
-                }
-            }
+            //// Check if the users access has expired
+            //if (_floodReport.ReportOwnerAccessUntil != null)
+            //{
+            //    _accessTimeLeft = _floodReport.ReportOwnerAccessUntil.Value - DateTimeOffset.UtcNow;
+            //    _accessHasExpired = _accessTimeLeft <= TimeSpan.Zero;
+            //}
+        }
 
-            _isLoading = false;
+        _isLoading = false;
+        StateHasChanged();
+    }
+
+    private void PerformAction(Guid FloodReportId)
+    {
+        navigationManager.NavigateTo($"{InvestigationPages.FirstPage.Url}/{FloodReportId}");
+        StateHasChanged();
+        return;
+    }
+
+    private void ViewReport(Guid FloodReportId)
+    {
+        navigationManager.NavigateTo($"{FloodReportPages.Overview.Url}/{FloodReportId}");
+        StateHasChanged();
+        return;
+    }
+
+    private void UpdateReport(Guid? EligibilityCheckId)
+    {
+        if (EligibilityCheckId.HasValue)
+        {
+            navigationManager.NavigateTo($"{FloodReportPages.Update.Url}/{EligibilityCheckId.Value}");
             StateHasChanged();
         }
+        return;
     }
 }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
@@ -5,7 +5,6 @@ using FloodOnlineReportingTool.Public.Services;
 using GdsBlazorComponents;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
-using NetTopologySuite.Index.HPRtree;
 using System.Security.Claims;
 
 namespace FloodOnlineReportingTool.Public.Components.Pages.FloodReport.Overview;
@@ -25,7 +24,7 @@ public partial class Index(
 
     private readonly CancellationTokenSource _cts = new();
     private bool _isLoading = true;
-    private IList<Database.Models.Flood.FloodReport> _floodReport = [];
+    private IList<Database.Models.Flood.FloodReport> _floodReports = [];
     private bool _accessHasExpired = true;
     private TimeSpan _accessTimeLeft;
 
@@ -69,6 +68,7 @@ public partial class Index(
             var localReport = await floodReportRepository.GetById(floodReportId, _cts.Token);
             if (localReport is null)
             {
+                _isLoading = false;
                 return;
             }
             _floodReport.Add((Database.Models.Flood.FloodReport)localReport);

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
@@ -107,7 +107,7 @@ public partial class Index(
 
     private void PerformAction(Guid FloodReportId)
     {
-        navigationManager.NavigateTo($"{InvestigationPages.FirstPage.Url}/{FloodReportId}");
+        navigationManager.NavigateTo($"{InvestigationPages.Home.Url}/{FloodReportId}");
         StateHasChanged();
         return;
     }

--- a/FloodOnlineReportingTool.Public/Components/Pages/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/Index.razor
@@ -26,10 +26,5 @@
         You will require the reference and access code which should have been sent to you in order to use this service.
     </div>
 
-    <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button govuk-button--start" data-module="govuk-button" href="@FloodReportPages.Overview.Url">
-        Manage an existing report
-        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-        </svg>
-    </a>
+    <GdsStartButton Href="@FloodReportPages.Overview.Url" Text="Manage an existing reports" />
 </div>


### PR DESCRIPTION
This pull request looks to deal with the issue of having multiple flood reports. The key changes are that:

- The overview page now shows a table with all your reports allowing you to manage them in one place.
- The details page has been updated to expect a flood report ID to be past. This page is focused on a single report. 
- There are tabs on the details page:
  - Overview (basically what we had before)
  - Eligibility form - the new component allowing the use to see the values they input
  - Investigation form - placeholder for the investigation summary. 

To make this work I've had to change a few fundamentals to unpick some of initial work which assumed that there would be a 121 relationship between flood reports and users. 

There is a 121 relationship between the flood report and its eligibility and investigation records but contacts are now linked 1 to many to any number of flood report records. 

I had to update the logic that generates the investigation record to reflect this change and add the FloodReportId to the investigationDto to ensure that the summary component knows which flood report to save the investigation record against. 

I've not put in pagination on the table for now as I doubt users will report enough for it to be an issue but if that does happen we may need to look at a more flexible table method. The current one uses the GDS table methods as described online. 

You should be able to fire up this branch and see / manage your reports directly from the home page using the navigations provided.  

Partially resolves #154 and #155 but does not cover unauthenticated use via magic link