### PR TITLE
Bug fix - Scalar not using client ID

### DIFF
--- a/FloodOnlineReportingTool.Public/Extensions/OpenApiExtensions.cs
+++ b/FloodOnlineReportingTool.Public/Extensions/OpenApiExtensions.cs
@@ -102,6 +102,7 @@ internal static class OpenApiExtensions
                     flows.WithAuthorizationCode(options =>
                     {
                         options.Pkce = Pkce.Sha256;
+                        options.CredentialsLocation = CredentialsLocation.Body;
                         if (identityOptions != null)
                         {
                             options.ClientId = identityOptions.ClientId;


### PR DESCRIPTION
small bug fix
Scalar was not putting the Client ID as a body parameter, meaning the auth was failing.
Where as Swagger was doing this so worked normally.

For clarity:
Both Swagger and Scaler are not using the Client Secret.