### PR TITLE
Generate more unique references using Crockford Base 32

### DIFF
--- a/Database/Repositories/FloodReportRepository.cs
+++ b/Database/Repositories/FloodReportRepository.cs
@@ -9,6 +9,7 @@ using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Security.Cryptography;
 
 namespace FloodOnlineReportingTool.Database.Repositories;
 
@@ -103,7 +104,7 @@ public class FloodReportRepository(
 
     private string CreateReference()
     {
-        var reference = Guid.CreateVersion7().ToString("N")[..8].ToUpperInvariant();
+        var reference = GenerateReferenceId();
         logger.LogInformation("Creating a new flood report reference number {Reference}.", reference);
         return reference;
     }
@@ -286,5 +287,22 @@ public class FloodReportRepository(
     public bool HasInvestigationStarted(Guid status)
     {
         return status == RecordStatusIds.ActionNeeded;
+    }
+
+    const string CrockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+    static string GenerateReferenceId()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(5); // 40 bits
+        ulong value = ((ulong)bytes[0] << 32) | ((ulong)bytes[1] << 24) |
+                      ((ulong)bytes[2] << 16) | ((ulong)bytes[3] << 8) | bytes[4];
+
+        Span<char> chars = stackalloc char[8];
+        for (int i = 7; i >= 0; i--)
+        {
+            chars[i] = CrockfordAlphabet[(int)(value & 0x1F)];
+            value >>= 5;
+        }
+        return new string(chars);
     }
 }

--- a/Database/Repositories/FloodReportRepository.cs
+++ b/Database/Repositories/FloodReportRepository.cs
@@ -102,11 +102,27 @@ public class FloodReportRepository(
         return CreateOrUpdateResult<FloodReport>.Success(floodReport);
     }
 
-    private string CreateReference()
+    private async Task<string> CreateReference(CancellationToken ct)
     {
         var reference = GenerateReferenceId();
-        logger.LogInformation("Creating a new flood report reference number {Reference}.", reference);
-        return reference;
+        //check existence of reference
+        var reportWithReferenceExists = await ReportWithReferenceExists(reference, ct);
+        var iteration = 0;
+        var maxIterations = 100;
+        while (reportWithReferenceExists && iteration < maxIterations)
+        {
+            reference = GenerateReferenceId();
+            reportWithReferenceExists = await ReportWithReferenceExists(reference, ct);
+            iteration++;
+        }
+        if(!reportWithReferenceExists)
+        {
+            logger.LogInformation("Creating a new flood report reference number {Reference}.", reference);
+            return reference;
+        }
+
+        logger.LogError("Could not generate a unique reference after {maxIterations} tries", maxIterations);
+        throw new Exception("Could not generate a unique reference");
     }
 
     public async Task<FloodReport?> GetById(Guid reference, CancellationToken ct)
@@ -157,6 +173,15 @@ public class FloodReportRepository(
             .FirstOrDefaultAsync(o => o.Reference == reference, ct);
     }
 
+    public async Task<bool> ReportWithReferenceExists(string reference, CancellationToken ct)
+    {
+        logger.LogInformation("Checking existence of flood report with reference number {Reference}.", reference);
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+        return await context.FloodReports
+            .AsNoTracking()
+            .AnyAsync(o => o.Reference == reference, ct);
+    }
+
     public async Task<(bool hasFloodReport, bool hasInvestigation, bool hasInvestigationStarted, DateTimeOffset? investigationCreatedUtc)> InvestigationBasicInformation(Guid FloodReportId, CancellationToken ct)
     {
         logger.LogInformation("Getting flood report details by id.");
@@ -205,7 +230,7 @@ public class FloodReportRepository(
 
         var floodReport = new FloodReport
         {
-            Reference = CreateReference(),
+            Reference = await CreateReference(ct),
             CreatedUtc = now,
             StatusId = RecordStatusIds.New,
             ReportOwnerAccessUntil = now.AddMonths(_gisOptions.AccessTokenIssueDurationMonths),
@@ -289,9 +314,9 @@ public class FloodReportRepository(
         return status == RecordStatusIds.ActionNeeded;
     }
 
-    const string CrockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    private const string CrockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
-    static string GenerateReferenceId()
+    private static string GenerateReferenceId()
     {
         var bytes = RandomNumberGenerator.GetBytes(5); // 40 bits
         ulong value = ((ulong)bytes[0] << 32) | ((ulong)bytes[1] << 24) |

--- a/Database/Repositories/IFloodReportRepository.cs
+++ b/Database/Repositories/IFloodReportRepository.cs
@@ -39,6 +39,11 @@ public interface IFloodReportRepository
     Task<FloodReport?> GetByReference(string reference, CancellationToken ct);
 
     /// <summary>
+    /// Check if a flood report exists with the given reference number.
+    /// </summary>
+    Task<bool> ReportWithReferenceExists(string reference, CancellationToken ct);
+
+    /// <summary>
     /// Get basic flood report information for the given user
     /// </summary>
     Task<(bool hasFloodReport, bool hasInvestigation, bool hasInvestigationStarted, DateTimeOffset? investigationCreatedUtc)> InvestigationBasicInformation(Guid FloodReportId, CancellationToken ct); 


### PR DESCRIPTION
This PR makes the generated references more unique by replacing the current Guid based method (which, due to its time based nature would generate duplicate references in the same 2 minute timespan) with a method based on [Crockford Base32](https://www.crockford.com/base32.html), which provides a much more unique reference number whilst still being short and simple. See the following fiddle for a comparison - https://dotnetfiddle.net/jV80gX

In testing, the chance of collisions is low but non-zero. Generating 100,000 reference numbers never caused a collision. Generating 1 million caused collisions about 50% of the time.

Copilot estimated the risk at 0.1% up to 47,000 ID generations.

## Potential improvements
The collision risk could be mitigated entirely by checking whether the generated reference exists in the database before setting it. If it does exist, we simply regenerate the ID and try again, up to a certain amount of attempts (e.g. try 20 times). At this point collisions become almost impossible.

We could also choose a different alphabet, such as Base 36 (0-9, A-Z) or Base62 (0-9, a-z, A-Z). Crockford Base32 was chosen as its readable (all upper case, excludes certain characters to prevent confusion) whilst still being pretty unique.

Fixes #156 