### PR TITLE
Fix async issue with loading lookup data in summary

### DIFF
--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Summary.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Summary.razor.cs
@@ -54,6 +54,7 @@ public partial class Summary(
     private string[] _sourceLabels = [];
     private string[] _secondarySourceLabels = [];
     private readonly CancellationTokenSource _cts = new();
+    private Task _initializationTask = Task.CompletedTask;
     private bool _isLoading = true;
     private List<ValidationFailure> _validationFailures = [];
 
@@ -72,9 +73,21 @@ public partial class Summary(
         GC.SuppressFinalize(this);
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
-        // Load persisted lookup data and avoid additional pre-render database calls.
+        // Store the task so OnAfterRenderAsync can await it, preventing a race
+        // condition during Blazor navigation where the render fires before
+        // the async initialization completes.
+        _initializationTask = LoadLookupDataAsync();
+
+        return _initializationTask;
+    }
+
+    /// <summary>
+    /// Load persisted lookup data and avoid additional pre-render database calls.
+    /// </summary>
+    private async Task LoadLookupDataAsync()
+    {
         EligibilityCheckFloodProblems ??= await GetEligibilityCheckFloodProblems();
         EligibilityCheckFloodImpacts ??= await GetEligibilityCheckFloodImpacts();
         if (Yes is null || No is null || NotSure is null)
@@ -87,6 +100,10 @@ public partial class Summary(
     {
         if (firstRender)
         {
+            // Ensure lookup data from OnInitializedAsync is fully loaded before proceeding.
+            // During Blazor navigation the render can fire before the async init completes.
+            await _initializationTask;
+
             _eligibilityCheckDto = await GetEligibilityCheckDto();
             _extraData = await GetCreateExtraData();
 


### PR DESCRIPTION
This PR fixes an issue where async behaviour caused data to not be loaded in the correct order. From the Blazor docs

> A component is re-entrant at any point where it awaits an incomplete Task. Lifecycle methods or component disposal methods may be called before the asynchronous control flow resumes.

What this meant in reality was, the `OnInitializedAsync` code ran first, but then hit an `await`, which allows the component to continue rendering with what it had available, triggering the `OnAfterRenderAsync` code. This code then calls methods such as `GetVulnerablePeople` which renders the friendly label for the summary, but this relies on the Yes/No/Not Sure labels being available, which they weren't when using enhanced navigation. Other properties would sometimes fail depending on how quickly the various awaited calls took. Full page reloads worked fine. 

Fixes #159 