### PR TITLE
Add loading UI when searching for nearest address and handle errors better

### DIFF
--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Location.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Location.razor
@@ -35,7 +35,12 @@
         }
 
         <div>
-            <p><button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">Continue</button></p>
+
+            
+            <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" disabled="@_isSearching">Continue</button>
+            <br/>
+            <GdsSpinner Show="_isSearching" ShowMessage="true" Message="Please wait whilst we search for the nearest property." />
+            
         </div>
     }
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Location.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Location.razor
@@ -35,12 +35,12 @@
         }
 
         <div>
-
-            
-            <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" disabled="@_isSearching">Continue</button>
-            <br/>
-            <GdsSpinner Show="_isSearching" ShowMessage="true" Message="Please wait whilst we search for the nearest property." />
-            
+            <p>
+                <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" disabled="@_isSearching">Continue</button>
+            </p>
+            <div>
+                <GdsSpinner Show="_isSearching" ShowMessage="true" Message="Please wait whilst we search for the nearest property." />
+            </div>
         </div>
     }
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Location.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Location.razor.cs
@@ -43,6 +43,8 @@ public partial class Location(
     private ValidationMessageStore _messageStore = default!;
     private readonly CancellationTokenSource _cts = new();
     private bool _isLoading = true;
+    //isSearching is seperate from _isLoading to allow for different UI
+    private bool _isSearching = false;
     private IJSObjectReference? _module;
     private ElementReference? _map;
     private DotNetObjectReference<Location>? _dotNetReference;
@@ -204,53 +206,78 @@ public partial class Location(
 
     private async Task OnValidSubmit()
     {
-        var createExtraData = await GetCreateExtraData();
-        var eligibilityCheck = await GetEligibilityCheck();
-        ExtraData? updatedExtraData = null;
-        bool propertyTypeReset = false;
+        _isSearching = true;
+        try
+        {
+            var createExtraData = await GetCreateExtraData();
+            var eligibilityCheck = await GetEligibilityCheck();
+
+            var updatedExtraData = await BuildUpdatedExtraData(createExtraData, eligibilityCheck);
+            if (updatedExtraData is not null)
+            {
+                await protectedSessionStorage.SetAsync(SessionConstants.EligibilityCheck_ExtraData, updatedExtraData);
+            }
+
+            var updatedEligibilityCheck = eligibilityCheck with
+            {
+                Easting = Model.Easting!.Value,
+                Northing = Model.Northing!.Value,
+                LocationDesc = Model.LocationDesc,
+            };
+            await protectedSessionStorage.SetAsync(SessionConstants.EligibilityCheck, updatedEligibilityCheck);
+
+            navigationManager.NavigateTo(NextPage.Url);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An error occurred while submitting the location.");
+
+            var errorField = FieldIdentifier.Create(() => Model.Easting);
+            _messageStore.Add(errorField, "There was a problem submitting your location. Please try again but if this issue happens again then please report a bug.");
+            _editContext.NotifyValidationStateChanged();
+        }
+        finally
+        {
+            _isSearching = false;
+        }
+    }
+
+    /// <summary>
+    /// Build updated extra data based on whether the user selected an address or changed location.
+    /// Returns null if no update is needed.
+    /// </summary>
+    private async Task<ExtraData?> BuildUpdatedExtraData(ExtraData createExtraData, EligibilityCheckDto eligibilityCheck)
+    {
         if (Model.IsAddress)
         {
             Model.Postcode = await GetPostcodeFromLocation();
+            if (string.IsNullOrEmpty(Model.Postcode))
+            {
+                throw new InvalidOperationException("Unable to find a postcode for the selected location.");
+            }
 
-            updatedExtraData = createExtraData with
+            return createExtraData with
             {
                 Postcode = Model.Postcode,
-                //PrimaryClassification = apiAddress.PrimaryClassification,
-                //SecondaryClassification = apiAddress.SecondaryClassification,
             };
-            propertyTypeReset = true;
-
         }
-        else if ((Model.Easting != eligibilityCheck.Easting || Model.Northing != eligibilityCheck.Northing))
+
+        // Location changed — reset property type selections so the user must re-choose
+        bool locationChanged = Model.Easting != eligibilityCheck.Easting
+                            || Model.Northing != eligibilityCheck.Northing;
+
+        if (locationChanged)
         {
-            //They changed the location so we reset the property type option
-            updatedExtraData = createExtraData with
+            return createExtraData with
             {
                 Postcode = null,
                 PrimaryClassification = null,
                 SecondaryClassification = null,
                 PropertyType = null,
             };
-            propertyTypeReset = true;
-        }
-        if (updatedExtraData != null)
-        {
-            await protectedSessionStorage.SetAsync(SessionConstants.EligibilityCheck_ExtraData, updatedExtraData);
         }
 
-        // Remember the entered postcode
-        var updatedEligibilityCheck = eligibilityCheck with
-        {
-            //Uprn = apiAddress.UPRN,
-            Easting = Model.Easting!.Value,
-            Northing = Model.Northing!.Value,
-            LocationDesc = Model.LocationDesc,
-
-        };
-        await protectedSessionStorage.SetAsync(SessionConstants.EligibilityCheck, updatedEligibilityCheck);
-
-        // Go to the next page or back to the summary
-        navigationManager.NavigateTo(NextPage.Url);
+        return null;
     }
 
     private async Task<EligibilityCheckDto> GetEligibilityCheck()

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Location.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/Location.razor.cs
@@ -43,7 +43,7 @@ public partial class Location(
     private ValidationMessageStore _messageStore = default!;
     private readonly CancellationTokenSource _cts = new();
     private bool _isLoading = true;
-    //isSearching is seperate from _isLoading to allow for different UI
+    // isSearching is separate from _isLoading to allow for different UI
     private bool _isSearching = false;
     private IJSObjectReference? _module;
     private ElementReference? _map;
@@ -259,6 +259,9 @@ public partial class Location(
             return createExtraData with
             {
                 Postcode = Model.Postcode,
+                PrimaryClassification = null,
+                SecondaryClassification = null,
+                PropertyType = null,
             };
         }
 


### PR DESCRIPTION
This PR adds a simple 'searching' UI to the location page when it is used to find the nearest property.

Previously this did nothing when the Continue button was hit, and if the API used to get the nearest property was slow, this would look like nothing happened. It now disables the Continue button and adds a loading spinner and message whilst the search is happening.

If the search failed, it would also take you to the 'Select Address' page, but with an error that didn't make much sense to the user in context. Now, if the search fails it keeps you on the same page, but with a validation style error that says explicitly that there was an error getting the nearest address.

Some reorganisation of the relevant code has also been implemented.