### PR TITLE
Overview page review

### DIFF
--- a/Database/Repositories/FloodReportRepository.cs
+++ b/Database/Repositories/FloodReportRepository.cs
@@ -125,6 +125,21 @@ public class FloodReportRepository(
         throw new Exception("Could not generate a unique reference");
     }
 
+    public async Task<IReadOnlyCollection<FloodReport>> GetAllOverview(CancellationToken ct)
+    {
+        logger.LogInformation("Getting all flood reports, with simple overview information.");
+
+        await using var context = await contextFactory.CreateDbContextAsync(ct);
+
+        return await context.FloodReports
+            .AsNoTracking()
+            .IgnoreAutoIncludes()
+            .Include(o => o.Status)
+            .Include(o => o.EligibilityCheck)
+            .OrderByDescending(o => o.CreatedUtc)
+            .ToListAsync(ct);
+    }
+
     public async Task<FloodReport?> GetById(Guid reference, CancellationToken ct)
     {
         logger.LogInformation("Getting flood report by id {Reference}.", reference);

--- a/Database/Repositories/IFloodReportRepository.cs
+++ b/Database/Repositories/IFloodReportRepository.cs
@@ -28,6 +28,12 @@ public interface IFloodReportRepository
     Task<CreateOrUpdateResult<FloodReport>> EnableContactSubscriptionsForReport(Guid floodReportId, CancellationToken ct);
 
     /// <summary>
+    /// Get all flood reports, with simple overview information.
+    /// </summary>
+    /// <remarks>Includes Status and EligibilityCheck. Not Investigation or ContactRecords. No related entities.</remarks>
+    Task<IReadOnlyCollection<FloodReport>> GetAllOverview(CancellationToken ct);
+
+    /// <summary>
     /// Flood report by ID.
     /// </summary>
     /// <returns></returns>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,7 +36,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
@@ -15,7 +15,7 @@
             <li>Use "@FloodReportPages.Details.Title" to see more details about a specific flood report</li>
         </ul>
 
-        <GdsTable T="Database.Models.Flood.FloodReport" Items="@_floodReports" Caption="Your flood reports" CaptionSize="GdsTableCaptionSize.Large" Density="GdsTableDensity.SmallTextUntilTablet">
+        <GdsTable T="Database.Models.Flood.FloodReport" Items="@_floodReports" Caption="@_tableCaption" CaptionSize="GdsTableCaptionSize.Large" Density="GdsTableDensity.SmallTextUntilTablet">
             <HeaderContent>
                 <GdsTableTh>Reference</GdsTableTh>
                 <GdsTableTh>Status</GdsTableTh>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
@@ -17,7 +17,7 @@
                     <li>view the flood report</li>
                     <li>change the flood report</li>
                     <li>view contact information</li>
-        </ul>
+                </ul>
             </li>
         </ul>
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
@@ -12,7 +12,13 @@
     @<div class="govuk-grid-column-full">
         <ul class="govuk-list">
             <li>@_manageText</li>
-            <li>Use "@FloodReportPages.Details.Title" to see more details about a specific flood report</li>
+            <li>Use the actions next to each flood report to:
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>view the flood report</li>
+                    <li>change the flood report</li>
+                    <li>view contact information</li>
+        </ul>
+            </li>
         </ul>
 
         <GdsTable T="Database.Models.Flood.FloodReport" Items="@_floodReports" Caption="@_tableCaption" CaptionSize="GdsTableCaptionSize.Large" Density="GdsTableDensity.SmallTextUntilTablet">
@@ -22,7 +28,7 @@
                 <GdsTableTh>Date reported</GdsTableTh>
                 <GdsTableTh>Address</GdsTableTh>
                 <GdsTableTh>Flooding date</GdsTableTh>
-                <GdsTableTh>Options</GdsTableTh>
+                <GdsTableTh>Actions</GdsTableTh>
             </HeaderContent>
             <RowTemplate Context="item">
                 <GdsTableTd Value="@item.Reference" />

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
@@ -1,124 +1,138 @@
-﻿@page "/floodreport/overview/{FloodReportId:guid?}"
-@page "/floodreport/overview"
+﻿@page "/floodreport/overview"
 @using FloodOnlineReportingTool.Contracts.Shared
-@using FloodOnlineReportingTool.Database.Models.Eligibility
 @using FloodOnlineReportingTool.Public.Authentication
 @using Microsoft.AspNetCore.Components.Authorization
 
-<PageTitle>@Title</PageTitle>
+<PageTitle>@FloodReportPages.Overview.Title</PageTitle>
 
-<GdsBreadcrumbs Items="@Breadcrumbs" />
+<GdsBreadcrumbs Items="@([GeneralPages.Home.ToGdsBreadcrumb()])" />
 
-<AuthorizeView Policy="@PolicyNames.Admin">
-    <Authorized>
-        <h1 class="govuk-heading-xl">The users flood report</h1>
-    </Authorized>
-    <NotAuthorized>
+@{
+    RenderFragment tableColumnFragment =
+    @<div class="govuk-grid-column-full">
+        <ul class="govuk-list">
+            <li>@_manageText</li>
+            <li>Use "@FloodReportPages.Details.Title" to see more details about a specific flood report</li>
+        </ul>
 
-    </NotAuthorized>
-</AuthorizeView>
+        <GdsTable T="Database.Models.Flood.FloodReport" Items="@_floodReports" Caption="Your flood reports" CaptionSize="GdsTableCaptionSize.Large" Density="GdsTableDensity.SmallTextUntilTablet">
+            <HeaderContent>
+                <GdsTableTh>Reference</GdsTableTh>
+                <GdsTableTh>Status</GdsTableTh>
+                <GdsTableTh>Date reported</GdsTableTh>
+                <GdsTableTh>Address</GdsTableTh>
+                <GdsTableTh>Flooding date</GdsTableTh>
+                <GdsTableTh>Options</GdsTableTh>
+            </HeaderContent>
+            <RowTemplate Context="item">
+                <GdsTableTd Value="@item.Reference" />
+                <GdsTableTd>
+                    @{
+                        var statusText = item.Status?.Text ?? "Unknown";
 
-<GdsSpinner Show="_isLoading" />
+                        if (item.StatusId == RecordStatusIds.ActionNeeded)
+                        {
+                            <GdsTag Colour="GdsTagColour.Yellow" Text="@statusText" />
+                        }
+                        else if (item.StatusId == RecordStatusIds.MarkedForDeletion)
+                        {
+                            <GdsTag Colour="GdsTagColour.Red" Text="@statusText" />
+                        }
+                        else
+                        {
+                            <GdsTag Colour="GdsTagColour.Green" Text="@statusText" />
+                        }
+                    }
+                </GdsTableTd>
+                <GdsTableTd Value="@item.CreatedUtc.GdsReadable()" />
+                <GdsTableTd Value="@item.EligibilityCheck?.LocationDesc" />
+                <GdsTableTd Value="@item.EligibilityCheck?.ImpactStart.GdsReadable()" />
+                <GdsTableTd>
+                    <div class="govuk-button-group">
+                        @if (item.StatusId == RecordStatusIds.ActionNeeded)
+                        {
+                            <GdsButton IsSubmit="false" Text="Tell us more" OnClick="@(() => PerformAction(item.Id))" />
+                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Details.Title" AdditionalCssClasses="govuk-button--secondary" OnClick="@(() => ViewReport(item.Id))" />
+                        } else
+                        {
+                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Details.Title" OnClick="@(() => ViewReport(item.Id))" />
+                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Update.Title" OnClick="@(() => UpdateReport(item.EligibilityCheckId))" />
+                        }
+                                        
+                    </div>
+                </GdsTableTd>
+            </RowTemplate>
+        </GdsTable>
+    </div>;
 
-@if (!_isLoading)
+    RenderFragment keepInformedColumnFragment =
+    @<div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-l">Keep informed</h2>
+
+        <!-- Contact details are per user so this should be the same in all contexts -->
+        <!-- If using a magic link there will only be one report so skip this page entirely! -->
+        @if (_floodReports.First().ContactRecords.Count > 0)
+        {
+            <p>Change your contact details if you would like to:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>receive updates</li>
+                <li>check the progress of your application</li>
+                <li>reset your login details</li>
+                <li>update your contact information</li>
+                <li>provide temporary contact information</li>
+            </ul>
+        }
+        else
+        {
+            <p>Give us your contact details if you would like to:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>receive updates</li>
+                <li>check the progress of your application</li>
+                <li>reset your login details</li>
+            </ul>
+        }
+
+        <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@ContactPages.Summary.Url">@ContactPages.Summary.Title</a>
+    </div>;
+}
+
+@if (_isLoading)
 {
-    <AuthorizeView>
-        <NotAuthorized>
-            <div class="govuk-grid-column-full">
-                <GdsWarning Text="We cannot find your flood reports." />
-            </div>
-        </NotAuthorized>
-        <Authorized>
-            <div class="govuk-grid-row">
+    <GdsSpinner Show />
+}
+else
+{
+    <h1 class="govuk-heading-xl">@_h1TitleText</h1>
+    <div class="govuk-grid-row">
+        <AuthorizeView>
+            <NotAuthorized>
                 @if (_floodReports.Count == 0)
                 {
                     <div class="govuk-grid-column-full">
-                        <GdsWarning Text="We cannot find your flood reports." />
+                        <GdsWarning Text="You need to sign in to view and manage your flood reports." />
+                        <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@_signInUrl">@AccountPages.SignIn.Title</a>
                     </div>
                 }
                 else
                 {
+                    @tableColumnFragment
+                    @keepInformedColumnFragment
+                }
+            </NotAuthorized>
+
+            <Authorized>
+                @if (_floodReports.Count == 0)
+                {
                     <div class="govuk-grid-column-full">
-                        <p class="govuk-body-l">
-                            This page will help you to find and manage your flood reports if you have reported more than once. Please use the "View report" option to find out more about the status of a specific report. 
-                        </p>
-
-                        <GdsTable T="Database.Models.Flood.FloodReport" Items="@_floodReports" Caption="Your flood reports" CaptionSize="GdsTableCaptionSize.Large" Density="GdsTableDensity.SmallTextUntilTablet">
-                            <HeaderContent>
-                                <GdsTableTh>Reference</GdsTableTh>
-                                <GdsTableTh>Status</GdsTableTh>
-                                <GdsTableTh>Date reported</GdsTableTh>
-                                <GdsTableTh>Address</GdsTableTh>
-                                <GdsTableTh>Flooding date</GdsTableTh>
-                                <GdsTableTh>Options</GdsTableTh>
-                            </HeaderContent>
-                            <RowTemplate Context="item">
-                                <GdsTableTd Value="@item.Reference" />
-                                <GdsTableTd>
-                                    @if (item.StatusId == RecordStatusIds.ActionNeeded)
-                                    {
-                                        <GdsTag Colour="GdsTagColour.Yellow" Text="@item.Status?.Text" />
-                                    }
-                                    else if (item.StatusId == RecordStatusIds.MarkedForDeletion)
-                                    {
-                                        <GdsTag Colour="GdsTagColour.Red" Text="@item.Status?.Text" />
-                                    }
-                                    else
-                                    {
-                                        <GdsTag Colour="GdsTagColour.Green" Text="@(item.Status?.Text?? "Unknown status")" />
-                                    }
-                                </GdsTableTd>
-                                <GdsTableTd Value="@item.CreatedUtc.GdsReadable()" />
-                                <GdsTableTd Value="@item.EligibilityCheck?.LocationDesc" />
-                                <GdsTableTd Value="@item.EligibilityCheck?.ImpactStart.GdsReadable()" />
-                                <GdsTableTd>
-                                    <div class="govuk-button-group">
-                                        @if (item.StatusId == RecordStatusIds.ActionNeeded)
-                                        {
-                                            <GdsButton IsSubmit="false" Text="Tell us more" OnClick="@(() => PerformAction(item.Id))" />
-                                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Overview.Title" AdditionalCssClasses="govuk-button--secondary" OnClick="@(() => ViewReport(item.Id))" />
-                                        } else
-                                        {
-                                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Overview.Title" OnClick="@(() => ViewReport(item.Id))" />
-                                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Update.Title" OnClick="@(() => UpdateReport(item.EligibilityCheckId))" />
-                                        }
-                                        
-                                    </div>
-                                </GdsTableTd>
-                            </RowTemplate>
-                        </GdsTable>
-                    </div>
-
-                    <div class="govuk-grid-column-full">
-                        <h2 class="govuk-heading-l">Keep informed</h2>
-
-                        <!-- Contact details are per user so this should be the same in all contexts -->
-                        <!-- If using a magic link there will only be one report so skip this page entirely! -->
-                        @if (_floodReports.First().ContactRecords.Count > 0)
-                        {
-                            <p>Change your contact details if you would like to:</p>
-                            <ul class="govuk-list govuk-list--bullet">
-                                <li>receive updates</li>
-                                <li>check the progress of your application</li>
-                                <li>reset your login details</li>
-                                <li>update your contact information</li>
-                                <li>provide temporary contact information</li>
-                            </ul>
-                        }
-                        else
-                        {
-                            <p>Give us your contact details if you would like to:</p>
-                            <ul class="govuk-list govuk-list--bullet">
-                                <li>receive updates</li>
-                                <li>check the progress of your application</li>
-                                <li>reset your login details</li>
-                            </ul>
-                        }
-
-                        <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@ContactPages.Summary.Url/@FloodReportId">@ContactPages.Summary.Title</a>
+                        <GdsWarning Text="@_noneFoundText" />
                     </div>
                 }
-            </div>
-        </Authorized>
-    </AuthorizeView>
+                else
+                {
+                    @tableColumnFragment
+                    @keepInformedColumnFragment
+                }
+            </Authorized>
+        </AuthorizeView>
+    </div>
 }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
@@ -54,18 +54,26 @@
                 <GdsTableTd Value="@item.EligibilityCheck?.LocationDesc" />
                 <GdsTableTd Value="@item.EligibilityCheck?.ImpactStart.GdsReadable()" />
                 <GdsTableTd>
-                    <div class="govuk-button-group">
+                    <ul class="govuk-list">
+                        <li>
+                            <a class="govuk-link" href="@($"{FloodReportPages.Details.Url}/{item.Id}")">View<span class="govuk-visually-hidden"> flood report</span></a>
+                        </li>
+                        @if (item.EligibilityCheckId.HasValue)
+                        {
+                            <li>
+                                <a class="govuk-link" href="@($"{FloodReportPages.Update.Url}/{item.EligibilityCheckId.Value}")">Update<span class="govuk-visually-hidden"> flood report</span></a>
+                            </li>
+                        }
+                        <li>
+                            <a class="govuk-link" href="@($"{ContactPages.Summary.Url}/{item.Id}")">Contacts<span class="govuk-visually-hidden"> information</span></a>
+                        </li>
                         @if (item.StatusId == RecordStatusIds.ActionNeeded)
                         {
-                            <GdsButton IsSubmit="false" Text="Tell us more" OnClick="@(() => PerformAction(item.Id))" />
-                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Details.Title" AdditionalCssClasses="govuk-button--secondary" OnClick="@(() => ViewReport(item.Id))" />
-                        } else
-                        {
-                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Details.Title" OnClick="@(() => ViewReport(item.Id))" />
-                            <GdsButton IsSubmit="false" Text="@FloodReportPages.Update.Title" OnClick="@(() => UpdateReport(item.EligibilityCheckId))" />
+                            <li>
+                                <a class="govuk-link" href="@($"{InvestigationPages.Home.Url}/{item.Id}")">Tell us more</a>
+                            </li>
                         }
-                                        
-                    </div>
+                    </ul>
                 </GdsTableTd>
             </RowTemplate>
         </GdsTable>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
@@ -58,12 +58,16 @@
                         <li>
                             <a class="govuk-link" href="@($"{FloodReportPages.Details.Url}/{item.Id}")">View<span class="govuk-visually-hidden"> flood report</span></a>
                         </li>
-                        @if (item.EligibilityCheckId.HasValue)
-                        {
-                            <li>
-                                <a class="govuk-link" href="@($"{FloodReportPages.Update.Url}/{item.EligibilityCheckId.Value}")">Update<span class="govuk-visually-hidden"> flood report</span></a>
-                            </li>
-                        }
+                        <AuthorizeView>
+                            <Authorized>
+                                @if (item.EligibilityCheckId.HasValue)
+                                {
+                                    <li>
+                                        <a class="govuk-link" href="@($"{FloodReportPages.Update.Url}/{item.EligibilityCheckId.Value}")">Update<span class="govuk-visually-hidden"> flood report</span></a>
+                                    </li>
+                                }
+                            </Authorized>
+                        </AuthorizeView>
                         <li>
                             <a class="govuk-link" href="@($"{ContactPages.Summary.Url}/{item.Id}")">Contacts<span class="govuk-visually-hidden"> information</span></a>
                         </li>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor
@@ -70,36 +70,6 @@
             </RowTemplate>
         </GdsTable>
     </div>;
-
-    RenderFragment keepInformedColumnFragment =
-    @<div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-l">Keep informed</h2>
-
-        <!-- Contact details are per user so this should be the same in all contexts -->
-        <!-- If using a magic link there will only be one report so skip this page entirely! -->
-        @if (_floodReports.First().ContactRecords.Count > 0)
-        {
-            <p>Change your contact details if you would like to:</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>receive updates</li>
-                <li>check the progress of your application</li>
-                <li>reset your login details</li>
-                <li>update your contact information</li>
-                <li>provide temporary contact information</li>
-            </ul>
-        }
-        else
-        {
-            <p>Give us your contact details if you would like to:</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li>receive updates</li>
-                <li>check the progress of your application</li>
-                <li>reset your login details</li>
-            </ul>
-        }
-
-        <a role="button" draggable="false" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button" href="@ContactPages.Summary.Url">@ContactPages.Summary.Title</a>
-    </div>;
 }
 
 @if (_isLoading)
@@ -122,7 +92,6 @@ else
                 else
                 {
                     @tableColumnFragment
-                    @keepInformedColumnFragment
                 }
             </NotAuthorized>
 
@@ -136,7 +105,6 @@ else
                 else
                 {
                     @tableColumnFragment
-                    @keepInformedColumnFragment
                 }
             </Authorized>
         </AuthorizeView>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
@@ -1,8 +1,8 @@
-﻿using FloodOnlineReportingTool.Database.Models.Eligibility;
-using FloodOnlineReportingTool.Database.Repositories;
+﻿using FloodOnlineReportingTool.Database.Repositories;
+using FloodOnlineReportingTool.Public.Authentication;
 using FloodOnlineReportingTool.Public.Models.Order;
 using FloodOnlineReportingTool.Public.Services;
-using GdsBlazorComponents;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using System.Security.Claims;
@@ -11,38 +11,23 @@ namespace FloodOnlineReportingTool.Public.Components.Pages.FloodReport.Overview;
 
 public partial class Index(
     IFloodReportRepository floodReportRepository,
+    IAuthorizationService authorizationService,
     NavigationManager navigationManager,
     SessionStateService scopedSessionStorage
-) : IPageOrder, IAsyncDisposable
+) : IAsyncDisposable
 {
-    // Page order properties
-    public string Title { get; set; } = FloodReportPages.Overview.Title;
-    public IReadOnlyCollection<GdsBreadcrumb> Breadcrumbs { get; set; } = [GeneralPages.Home.ToGdsBreadcrumb()];
-
     [CascadingParameter]
     public Task<AuthenticationState>? AuthenticationState { get; set; }
 
-    [Parameter]
-    public Guid? FloodReportId { get; set; }
-    private Guid _floodReportId = Guid.Empty;
+    // Text which changes for users and admins
+    private string _h1TitleText = FloodReportPages.Overview.Title;
+    private string _manageText = "Manage your flood reports";
+    private string _noneFoundText = "We cannot find your flood reports.";
 
     private readonly CancellationTokenSource _cts = new();
     private bool _isLoading = true;
-    private IList<Database.Models.Flood.FloodReport> _floodReports = [];
-    private bool _accessHasExpired = true;
-    private TimeSpan _accessTimeLeft;
-
-    // These are returning information about the current record
-    private EligibilityOptions _floodInvestigation;
-    //private IList<Organisation> _leadLocalFloodAuthorities = [];
-    //private IList<Organisation> _otherFloodAuthorities = [];
-
-    // These don't have any logic yet in the repository
-    private bool _isEmergencyResponse;
-    private string? _section19Url;
-    private EligibilityOptions _grantApplication;
-    private EligibilityOptions _propertyProtection;
-    private EligibilityOptions _section19;
+    private IReadOnlyCollection<Database.Models.Flood.FloodReport> _floodReports = [];
+    private readonly string _signInUrl = $"{AccountPages.SignIn.Url}?redirectUri={navigationManager.SignInRedirectUri}";
 
     public async ValueTask DisposeAsync()
     {
@@ -58,78 +43,124 @@ public partial class Index(
         GC.SuppressFinalize(this);
     }
 
-    protected override async Task OnParametersSetAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        string? userId = null;
-        if (AuthenticationState is not null)
+        if (firstRender)
         {
-            var authState = await AuthenticationState;
-            userId = authState.User.Oid;
-        }
-        if (userId is null)
-        {
-            _floodReportId = FloodReportId ?? await scopedSessionStorage.GetFloodReportId();
-            var localReport = await floodReportRepository.GetById(_floodReportId, _cts.Token);
-            if (localReport is null)
+            /*
+             * scenarios to handle:
+             * Not authenicated
+             * Not authenticated with flood report ID in protected session storage
+             * Authenticated as an admin
+             * Authenticated as a user
+             */
+
+            if (AuthenticationState is not null)
             {
-                _isLoading = false;
-                return;
+                var authState = await AuthenticationState;
+                if (authState.User.IsAuthenticated)
+                {
+                    var adminPolicyCheck = await authorizationService.AuthorizeAsync(authState.User, PolicyNames.Admin);
+                    var hasAdminPolicy = adminPolicyCheck.Succeeded;
+
+                    _floodReports = hasAdminPolicy
+                        ? await GetAdminsFloodReports(authState, hasAdminPolicy)
+                        : await GetCurrentUsersFloodReports(authState, hasAdminPolicy);
+                }
+                else
+                {
+                    _floodReports = await GetStoredFloodReports(authState);
+                }
             }
-            _floodReports.Add((Database.Models.Flood.FloodReport)localReport);
-        }
-        else
-        {
-            _floodReports = [.. await floodReportRepository.AllReportedByContact(userId, _cts.Token)];
-        }
 
-        if (_floodReports.Count > 0)
-        {
-            //var result = await floodReportRepository.CalculateEligibilityWithReference(_floodReports.Reference, _cts.Token);
-
-            ////_leadLocalFloodAuthorities = [.. result.ResponsibleOrganisations.Where(o => o.FloodAuthorityId == FloodAuthorityIds.LeadLocalFloodAuthority)];
-            ////_otherFloodAuthorities = [.. result.ResponsibleOrganisations.Where(o => o.FloodAuthorityId != FloodAuthorityIds.LeadLocalFloodAuthority)];
-
-            //// These don't have any logic yet in the repository
-            //_floodInvestigation = result.FloodInvestigation;
-            //_isEmergencyResponse = result.IsEmergencyResponse;
-            //_section19Url = result.Section19Url;
-            //_section19 = result.Section19;
-            //_propertyProtection = result.PropertyProtection;
-            //_grantApplication = result.GrantApplication;
-
-            //// Check if the users access has expired
-            //if (_floodReport.ReportOwnerAccessUntil != null)
-            //{
-            //    _accessTimeLeft = _floodReport.ReportOwnerAccessUntil.Value - DateTimeOffset.UtcNow;
-            //    _accessHasExpired = _accessTimeLeft <= TimeSpan.Zero;
-            //}
-        }
-
-        _isLoading = false;
-        StateHasChanged();
-    }
-
-    private void PerformAction(Guid FloodReportId)
-    {
-        navigationManager.NavigateTo($"{InvestigationPages.Home.Url}/{FloodReportId}");
-        StateHasChanged();
-        return;
-    }
-
-    private void ViewReport(Guid FloodReportId)
-    {
-        navigationManager.NavigateTo($"{FloodReportPages.Details.Url}/{FloodReportId}");
-        StateHasChanged();
-        return;
-    }
-
-    private void UpdateReport(Guid? EligibilityCheckId)
-    {
-        if (EligibilityCheckId.HasValue)
-        {
-            navigationManager.NavigateTo($"{FloodReportPages.Update.Url}/{EligibilityCheckId.Value}");
+            _isLoading = false;
             StateHasChanged();
         }
-        return;
+    }
+
+    private void PerformAction(Guid floodReportId)
+    {
+        navigationManager.NavigateTo($"{InvestigationPages.Home.Url}/{floodReportId}");
+    }
+
+    private void ViewReport(Guid floodReportId)
+    {
+        navigationManager.NavigateTo($"{FloodReportPages.Details.Url}/{floodReportId}");
+    }
+
+    private void UpdateReport(Guid? eligibilityCheckId)
+    {
+        if (eligibilityCheckId.HasValue)
+        {
+            navigationManager.NavigateTo($"{FloodReportPages.Update.Url}/{eligibilityCheckId.Value}");
+        }
+    }
+
+    /// <summary>
+    /// Gets all flood reports
+    /// </summary>
+    /// <remarks>The user has to be authenticated, and an admin.</remarks>
+    private async Task<IReadOnlyCollection<Database.Models.Flood.FloodReport>> GetAdminsFloodReports(AuthenticationState authState, bool hasAdminPolicy)
+    {
+        if (!authState.User.IsAuthenticated || !hasAdminPolicy)
+        {
+            return [];
+        }
+
+        // Update the title, manage text, and none found text for admins
+        _h1TitleText = "View all flood reports";
+        _manageText = "Manage all flood reports";
+        _noneFoundText = "We cannot find any flood reports.";
+
+        return await floodReportRepository.GetAllOverview(_cts.Token);
+    }
+
+    /// <summary>
+    /// Get the current users floods reports
+    /// </summary>
+    /// <remarks>The user has to be authenticated, and NOT an admin.</remarks>
+    private async Task<IReadOnlyCollection<Database.Models.Flood.FloodReport>> GetCurrentUsersFloodReports(AuthenticationState authState, bool hasAdminPolicy)
+    {
+        if (!authState.User.IsAuthenticated || hasAdminPolicy)
+        {
+            return [];
+        }
+
+        string? userId = authState.User.Oid;
+        if (userId is null)
+        {
+            return [];
+        }
+
+        return await floodReportRepository.AllReportedByContact(userId, _cts.Token);
+    }
+
+    /// <summary>
+    /// Get the stored flood report
+    /// </summary>
+    /// <remarks>
+    ///     <para>The user has to not be authenticated. Flood report ID exists in protected storage.</para>
+    ///     <para>This can happen from the /floodreport/create/confirmation page</para>
+    /// </remarks>
+    private async Task<IReadOnlyCollection<Database.Models.Flood.FloodReport>> GetStoredFloodReports(AuthenticationState authState)
+    {
+        if (authState.User.IsAuthenticated)
+        {
+            return [];
+        }
+
+        var floodReportId = await scopedSessionStorage.GetFloodReportId();
+        if (floodReportId == Guid.Empty)
+        {
+            return [];
+        }
+
+        var floodReport = await floodReportRepository.GetById(floodReportId, _cts.Token);
+        if (floodReport is null)
+        {
+            return [];
+        }
+
+        return [floodReport];
     }
 }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
@@ -81,24 +81,6 @@ public partial class Index(
         }
     }
 
-    private void PerformAction(Guid floodReportId)
-    {
-        navigationManager.NavigateTo($"{InvestigationPages.Home.Url}/{floodReportId}");
-    }
-
-    private void ViewReport(Guid floodReportId)
-    {
-        navigationManager.NavigateTo($"{FloodReportPages.Details.Url}/{floodReportId}");
-    }
-
-    private void UpdateReport(Guid? eligibilityCheckId)
-    {
-        if (eligibilityCheckId.HasValue)
-        {
-            navigationManager.NavigateTo($"{FloodReportPages.Update.Url}/{eligibilityCheckId.Value}");
-        }
-    }
-
     /// <summary>
     /// Gets all flood reports
     /// </summary>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
@@ -23,6 +23,7 @@ public partial class Index(
     private string _h1TitleText = FloodReportPages.Overview.Title;
     private string _manageText = "Manage your flood reports";
     private string _noneFoundText = "We cannot find your flood reports.";
+    private string _tableCaption = "Your flood reports";
 
     private readonly CancellationTokenSource _cts = new();
     private bool _isLoading = true;
@@ -111,6 +112,7 @@ public partial class Index(
         _h1TitleText = "View all flood reports";
         _manageText = "Manage all flood reports";
         _noneFoundText = "We cannot find any flood reports.";
+        _tableCaption = "All flood reports";
 
         return await floodReportRepository.GetAllOverview(_cts.Token);
     }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
@@ -28,7 +28,9 @@ public partial class Index(
     private readonly CancellationTokenSource _cts = new();
     private bool _isLoading = true;
     private IReadOnlyCollection<Database.Models.Flood.FloodReport> _floodReports = [];
-    private readonly string _signInUrl = $"{AccountPages.SignIn.Url}?redirectUri={navigationManager.SignInRedirectUri}";
+    private readonly string _signInUrl = string.IsNullOrWhiteSpace(navigationManager.SignInRedirectUri)
+        ? AccountPages.SignIn.Url
+        : $"{AccountPages.SignIn.Url}?redirectUri={navigationManager.SignInRedirectUri}";
 
     public async ValueTask DisposeAsync()
     {

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Overview/Index.razor.cs
@@ -49,7 +49,7 @@ public partial class Index(
         {
             /*
              * scenarios to handle:
-             * Not authenicated
+             * Not authenticated
              * Not authenticated with flood report ID in protected session storage
              * Authenticated as an admin
              * Authenticated as a user


### PR DESCRIPTION
- Reviewed the overview page
- Removed unused comment blocks
- Fixed bugs in logic
- Fixed issues with not authenticated users and stored flood report in protected storage
- New flood report repository method to get all flood reports, cut down/basic/overview
- Updated OpenTelemetryProtocol to fix a vulnerability
- Removed keep informed section as it made no sense with the overview page's purpose
- Changed option buttons to action links
- Linked all actions to the specific flood report

To make the overview page work correctly there were a lot of changes to this 1 page.
It had to cope with these complex auth combinations:
1. Not authenticated
2. Not authenticated with flood report ID in protected session storage
3. Authenticated as an admin
4. Authenticated as a user

The way Blazor works with the &lt;AuthorizeView&gt; component it will still run code in lifecycle methods like OnParametersSet.
I made sure the lifecycle methods check auth before deciding what data to fetch.

Point 2. above was hard to fix in the razor page without using RenderFragments.

The clearest places to see how the page now works are:
- the bottom part of Index.razor
- OnAfterRenderAsync in Index.razor.cs

Notes:
The admin features of this page will need improving, add paging etc.
The Contacts action link is unchanged but behaves strangely. It redirects to a subscribe page. And cancelling it goes to the create flood report confirmation page.