### PR TITLE
Bugfix for partial dates

### DIFF
--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/FloodStarted.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/FloodStarted.razor.cs
@@ -91,6 +91,18 @@ public partial class FloodStarted(
 
     private async Task OnSubmit()
     {
+        // Handle two digit years by assuming they are in the 2000s
+        DateTimeOffset? currentDate = Model.StartDate.DateUtc;
+        if (currentDate.HasValue)
+        {
+            int year = currentDate.Value.Year;
+            if (year >= 0 && year <= 99)
+            {
+                DateTimeOffset newDate = currentDate.Value.AddYears(2000);
+                Model.StartDate = new GdsDate(newDate);
+            }
+        }
+        
         if (_editContext.Validate())
         {
             await OnValidSubmit();

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/FloodStarted.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/FloodStarted.razor.cs
@@ -96,7 +96,7 @@ public partial class FloodStarted(
         if (currentDate.HasValue)
         {
             int year = currentDate.Value.Year;
-            if (year >= 0 && year <= 99)
+            if (year <= 99)
             {
                 DateTimeOffset newDate = currentDate.Value.AddYears(2000);
                 Model.StartDate = new GdsDate(newDate);

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/FloodStarted.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Create/FloodStarted.razor.cs
@@ -5,6 +5,7 @@ using GdsBlazorComponents;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using System.Globalization;
 
 namespace FloodOnlineReportingTool.Public.Components.Pages.FloodReport.Create;
 
@@ -98,8 +99,9 @@ public partial class FloodStarted(
             int year = currentDate.Value.Year;
             if (year <= 99)
             {
-                DateTimeOffset newDate = currentDate.Value.AddYears(2000);
-                Model.StartDate = new GdsDate(newDate);
+                int adjustedYear = CultureInfo.CurrentCulture.Calendar.ToFourDigitYear(year);
+                Model.StartDate.YearText = adjustedYear.ToString(CultureInfo.CurrentCulture);
+                // Note: Can't use Model.StartDate.Year as it is currently designed as read only
             }
         }
         


### PR DESCRIPTION
This PR fixes a minor bug where if a user enters a year using only 2 digits (for example '26' instead of '2026'), validation would fail. I've added an if statement to catch any of these and assume they should be in the 2000s.

Closes #177