### PR TITLE
Update dependencies to remove vulnerable packages.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Dorset-Council-UK.FloodOnlineReportingTool.Contracts" Version="6.0.2-beta" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageVersion Include="GovukNotify" Version="7.2.0" />
+    <PackageVersion Include="GovukNotify" Version="8.1.0" />
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.79" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
@@ -28,9 +28,9 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="10.3.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="4.4.0" />
-    <PackageVersion Include="Microsoft.Identity.Web.DownstreamApi" Version="4.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.9.0" />
+    <PackageVersion Include="Microsoft.Identity.Web.DownstreamApi" Version="4.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />


### PR DESCRIPTION
This pull request updates several package dependencies in the `Directory.Packages.props` file to keep the project up to date with the latest features and security patches.

**Dependency updates:**

* Upgraded `GovukNotify` from version 7.2.0 to 8.1.0.
* Upgraded `Microsoft.Identity.Web` and `Microsoft.Identity.Web.DownstreamApi` from version 4.4.0 to 4.9.0.
* Upgraded `Microsoft.NET.Test.Sdk` from version 18.3.0 to 18.6.0.