### PR TITLE
Improve UX of media upload

### DIFF
--- a/Database/Repositories/IMediaItemRepository.cs
+++ b/Database/Repositories/IMediaItemRepository.cs
@@ -22,6 +22,12 @@ public interface IMediaItemRepository
     Task<Result<IReadOnlyCollection<MediaItem>>> Create(Guid floodReportId, IReadOnlyCollection<MediaItem> mediaItems, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Update the title of a media item.
+    /// </summary>
+    /// <returns>A result pattern with the updated media item, or a list of errors.</returns>
+    Task<Result<MediaItem>> UpdateTitle(Guid mediaItemId, string title, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Delete a media item by ID.
     /// </summary>
     /// <returns>A result pattern indicating success, or a list of errors.</returns>

--- a/Database/Repositories/MediaItemRepository.cs
+++ b/Database/Repositories/MediaItemRepository.cs
@@ -107,4 +107,23 @@ public class MediaItemRepository(
 
         return DeleteResult<MediaItem>.Success();
     }
+
+    public async Task<Result<MediaItem>> UpdateTitle(Guid mediaItemId, string title, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Updating title for media item ID: {MediaItemId}", mediaItemId);
+
+        await using var context = await contextFactory.CreateDbContextAsync(cancellationToken);
+        var mediaItem = await context.MediaItems
+            .FirstOrDefaultAsync(mi => mi.Id == mediaItemId, cancellationToken);
+
+        if (mediaItem is null)
+        {
+            return Result<MediaItem>.Failure([$"No media item found for ID {mediaItemId}"]);
+        }
+
+        mediaItem.Title = title;
+        await context.SaveChangesAsync(cancellationToken);
+
+        return Result<MediaItem>.Success(mediaItem);
+    }
 }

--- a/Database/Repositories/MediaItemRepository.cs
+++ b/Database/Repositories/MediaItemRepository.cs
@@ -4,6 +4,7 @@ using FloodOnlineReportingTool.Database.Models.Flood;
 using FloodOnlineReportingTool.Database.Models.ResultModels;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace FloodOnlineReportingTool.Database.Repositories;
 
@@ -99,7 +100,7 @@ public class MediaItemRepository(
 
         if (mediaItem is null)
         {
-            return DeleteResult<MediaItem>.Failure([$"No media item found for ID {mediaItemId}"]);
+            return DeleteResult<MediaItem>.Failure([$"An error occurred deleting the media item"]);
         }
 
         context.MediaItems.Remove(mediaItem);
@@ -118,7 +119,8 @@ public class MediaItemRepository(
 
         if (mediaItem is null)
         {
-            return Result<MediaItem>.Failure([$"No media item found for ID {mediaItemId}"]);
+            logger.LogWarning(message: "Couldn't rename media item. No media item found for ID {mediaItemId}", mediaItemId);
+            return Result<MediaItem>.Failure([$"An error occurred renaming the media item"]);
         }
 
         mediaItem.Title = title;

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
@@ -3,7 +3,7 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.Extensions.Options
 @using FloodOnlineReportingTool.Public.Options
-@inject IOptions<AzureBlobStorageOptions> blobStoageOptions;
+@inject IOptions<AzureBlobStorageOptions> blobStoageOptions
 <PageTitle>@Title</PageTitle>
 
 <GdsBackLink Href="@PreviousPage.Url"></GdsBackLink>
@@ -78,7 +78,7 @@
                                 <td class="govuk-table__cell">
                                     @if (ImageFileTypes.Contains(file.ContentType))
                                     {
-                                        <img class="media-image-preview" src="@(file.Url)?@(blobStoageOptions.Value.ReadSASToken)" alt="Preview of @file.Name" />
+<img class="media-image-preview" src="@(string.IsNullOrWhiteSpace(blobStoageOptions.Value.ReadSASToken) ? file.Url : $"{file.Url}?{blobStoageOptions.Value.ReadSASToken.TrimStart('?')}")" alt="Preview of @file.Name" />
                                     }
                                     else if(VideoFileTypes.Contains(file.ContentType))
                                     {
@@ -127,7 +127,7 @@
                                 </td>
                                 <td class="govuk-table__cell">
                                     <button type="button" class="govuk-button govuk-button--warning" @onclick="() => DeleteUploadedFile(file)">Delete file</button>
-                                    <a href="@(file.Url)?@(blobStoageOptions.Value.ReadSASToken)" target="_blank" rel="noreferrer noopener" class="govuk-button govuk-button--secondary">View<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
+<a href="@(string.IsNullOrWhiteSpace(blobStoageOptions.Value.ReadSASToken) ? file.Url : $"{file.Url}?{blobStoageOptions.Value.ReadSASToken.TrimStart('?')}")" target="_blank" rel="noreferrer noopener" class="govuk-button govuk-button--secondary">View<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
                                 </td>
                             </tr>
                         }
@@ -137,7 +137,7 @@
                             <tr class="govuk-table__row">
                                 <td class="govuk-table__cell">
                                     <span class="media-placeholder">
-                                        <img src="@Assets["/images/ban.svg"]" alt="Document file icon" class="media-placeholder__icon" />
+<img src="@Assets["/images/ban.svg"]" alt="Rejected file icon" class="media-placeholder__icon" />
                                     </span>
                                 </td>
                                 <td class="govuk-table__cell">@rejectedFile.File.Name<br /><span class="govuk-error-message">@errorMessage</span></td>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
@@ -80,10 +80,19 @@
                                     {
                                         <img class="media-image-preview" src="@(file.Url)?@(blobStoageOptions.Value.ReadSASToken)" alt="Preview of @file.Name" />
                                     }
-                                    else
+                                    else if(VideoFileTypes.Contains(file.ContentType))
                                     {
-                                        <span>No preview</span>
+                                        <span class="media-placeholder">
+                                            <img src="@Assets["/images/video-preview.svg"]" alt="Video file icon" class="media-placeholder__icon" />
+                                        </span>
                                     }
+                                    else if (DocumentFileTypes.Contains(file.ContentType))
+                                    {
+                                        <span class="media-placeholder">
+                                            <img src="@Assets["/images/file-preview.svg"]" alt="Document file icon" class="media-placeholder__icon" />
+                                        </span>
+                                    }
+                                    
                                 </td>
                                 <td class="govuk-table__cell">@file.Name</td>
                                 <td class="govuk-table__cell">

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
@@ -1,7 +1,9 @@
 ﻿@page "/floodreport/media/add-photos-or-videos/{FloodReportId:guid?}"
 @page "/floodreport/media/add-photos-or-videos"
 @using Microsoft.AspNetCore.Components.Authorization
-
+@using Microsoft.Extensions.Options
+@using FloodOnlineReportingTool.Public.Options
+@inject IOptions<AzureBlobStorageOptions> blobStoageOptions;
 <PageTitle>@Title</PageTitle>
 
 <GdsBackLink Href="@PreviousPage.Url"></GdsBackLink>
@@ -49,6 +51,7 @@
                 <table class="govuk-table">
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">
+                            <th scope="col" class="govuk-table__header">Preview</th>
                             <th scope="col" class="govuk-table__header">File</th>
                             <th scope="col" class="govuk-table__header">Status</th>
                             <th scope="col" class="govuk-table__header">Actions</th>
@@ -58,6 +61,7 @@
                         @foreach (var file in _uploadingFiles)
                         {
                             <tr class="govuk-table__row">
+                                <td class="govuk-table__cell"><GdsSpinner Show="true" ShowMessage="false"></GdsSpinner></td>
                                 <td class="govuk-table__cell">@file.Name</td>
                                 <td class="govuk-table__cell">
                                     <strong class="govuk-tag govuk-tag--blue">
@@ -71,6 +75,16 @@
                         @foreach (var file in Model.UploadedFiles)
                         {
                             <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    @if (ImageFileTypes.Contains(file.ContentType))
+                                    {
+                                        <img class="media-image-preview" src="@(file.Url)?@(blobStoageOptions.Value.ReadSASToken)" alt="Preview of @file.Name" />
+                                    }
+                                    else
+                                    {
+                                        <span>No preview</span>
+                                    }
+                                </td>
                                 <td class="govuk-table__cell">@file.Name</td>
                                 <td class="govuk-table__cell">
                                     <strong class="govuk-tag govuk-tag--green">
@@ -86,6 +100,7 @@
                         {
                             var errorMessage = GetErrorMessageForFile(rejectedFile);
                             <tr class="govuk-table__row">
+                                <td class="govuk-table__cell"><img src="@(Assets["~/images/ban.svg"])" alt="Failed image upload icon" /></td>
                                 <td class="govuk-table__cell">@rejectedFile.File.Name<br /><span class="govuk-error-message">@errorMessage</span></td>
                                 <td class="govuk-table__cell">
                                     <strong class="govuk-tag govuk-tag--red">

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
@@ -94,7 +94,26 @@
                                     }
                                     
                                 </td>
-                                <td class="govuk-table__cell">@file.Name</td>
+                                <td class="govuk-table__cell">
+                                    @if (_renamingFile == file)
+                                    {
+                                        <GdsFormGroup For="() => _renameText">
+                                            <GdsLabel Text="File name" />
+                                            <GdsErrorMessage />
+                                            <GdsInputText @bind-Value="_renameText" @bind:event="oninput" class="govuk-input govuk-input--width-20" />
+                                        </GdsFormGroup>
+
+                                        <div class="govuk-button-group govuk-!-margin-top-2">
+                                            <button type="button" class="govuk-button govuk-button--primary" @onclick="() => SaveRename(file)">Save</button>
+                                            <button type="button" class="govuk-button govuk-button--secondary" @onclick="CancelRename">Cancel</button>
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        @file.Name
+                                        <br /><button type="button" class="govuk-link govuk-link--no-visited-state" @onclick="() => StartRename(file)" @onclick:preventDefault>Rename<span class="govuk-visually-hidden"> file '@file.Name'</span></button>
+                                    }
+                                </td>
                                 <td class="govuk-table__cell">
                                     <strong class="govuk-tag govuk-tag--green">
                                         Uploaded

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
@@ -97,13 +97,19 @@
                                 <td class="govuk-table__cell">
                                     @if (_renamingFile == file)
                                     {
-                                        <GdsFormGroup For="() => _renameText">
+                                        <GdsFormGroup For="() => _renameText" AdditionalCssClasses="@($"govuk-!-margin-bottom-2{(_renameError is not null ? " govuk-form-group--error" : "")}")">
                                             <GdsLabel Text="File name" />
-                                            <GdsErrorMessage />
-                                            <GdsInputText @bind-Value="_renameText" @bind:event="oninput" class="govuk-input govuk-input--width-20" />
+                                            @if (_renameError is not null)
+                                            {
+                                                <p class="govuk-error-message">
+                                                    <span class="govuk-visually-hidden">Error:</span>
+                                                    @_renameError
+                                                </p>
+                                            }
+                                            <GdsInputText @bind-Value="_renameText" @bind:event="oninput" class="@($"govuk-input govuk-input--width-20{(_renameError is not null ? " govuk-input--error" : "")}")" />
                                         </GdsFormGroup>
 
-                                        <div class="govuk-button-group govuk-!-margin-top-2">
+                                        <div class="govuk-button-group">
                                             <button type="button" class="govuk-button govuk-button--primary" @onclick="() => SaveRename(file)">Save</button>
                                             <button type="button" class="govuk-button govuk-button--secondary" @onclick="CancelRename">Cancel</button>
                                         </div>

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor
@@ -101,7 +101,8 @@
                                     </strong>
                                 </td>
                                 <td class="govuk-table__cell">
-                                    <button type="button" class="govuk-button govuk-button--secondary" @onclick="() => DeleteUploadedFile(file)">Delete file</button>
+                                    <button type="button" class="govuk-button govuk-button--warning" @onclick="() => DeleteUploadedFile(file)">Delete file</button>
+                                    <a href="@(file.Url)?@(blobStoageOptions.Value.ReadSASToken)" target="_blank" rel="noreferrer noopener" class="govuk-button govuk-button--secondary">View<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
                                 </td>
                             </tr>
                         }
@@ -109,7 +110,11 @@
                         {
                             var errorMessage = GetErrorMessageForFile(rejectedFile);
                             <tr class="govuk-table__row">
-                                <td class="govuk-table__cell"><img src="@(Assets["~/images/ban.svg"])" alt="Failed image upload icon" /></td>
+                                <td class="govuk-table__cell">
+                                    <span class="media-placeholder">
+                                        <img src="@Assets["/images/ban.svg"]" alt="Document file icon" class="media-placeholder__icon" />
+                                    </span>
+                                </td>
                                 <td class="govuk-table__cell">@rejectedFile.File.Name<br /><span class="govuk-error-message">@errorMessage</span></td>
                                 <td class="govuk-table__cell">
                                     <strong class="govuk-tag govuk-tag--red">
@@ -117,7 +122,7 @@
                                     </strong>
                                 </td>
                                 <td class="govuk-table__cell">
-                                    <button type="button" class="govuk-button govuk-button--secondary" @onclick="() => DeleteRejectedFile(rejectedFile)">Delete file</button>
+                                    <button type="button" class="govuk-button govuk-button--warning" @onclick="() => DeleteRejectedFile(rejectedFile)">Delete file</button>
                                 </td>
                             </tr>
                         }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
@@ -264,13 +264,7 @@ public partial class Index(
             var result = await mediaItemRepository.UpdateTitle(file.Id.Value, _renameText, _cts.Token);
             if (!result.IsSuccess)
             {
-                foreach (var error in result.Errors)
-                {
-                    logger.LogWarning("Couldn't rename media item: {ErrorMessage}", error);
-                }
-
-                _validationMessageStore.Add(_fieldIdentifier, "Sorry, something went wrong");
-                _editContext.NotifyValidationStateChanged();
+                _renameError = string.Join(", ", result.Errors);
                 return;
             }
         }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
@@ -38,16 +38,24 @@ public partial class Index(
     private const long MaxFileSize = MaxFileSizeMB * 1024 * 1024; // Convert MB to bytes
 
     private int RemainingSlots => MaxNumFiles - Model.UploadedFiles.Count;
-
-    private static readonly string[] AllowedFileTypes = [
+    private static readonly string[] ImageFileTypes = [
         "image/jpeg",
         "image/jpg",
         "image/png",
         "image/gif",
+    ];
+    private static readonly string[] VideoFileTypes = [
         "video/mp4",
         "video/webm",
         "video/ogg",
-        "application/pdf",
+    ];
+    private static readonly string[] DocumentFileTypes = [
+        "application/pdf"
+    ];
+    private static readonly string[] AllowedFileTypes = [
+        .. ImageFileTypes, 
+        .. VideoFileTypes, 
+        .. DocumentFileTypes,
     ];
 
     private static readonly string[] FriendlyFileTypes = [
@@ -121,7 +129,7 @@ public partial class Index(
                 Id = mediaItem.Id,
                 Name = mediaItem.Title ?? Path.GetFileName(mediaItem.URL),
                 Url = mediaItem.URL,
-                ContentType = string.Empty,
+                ContentType = GetContentTypeFromUrl(mediaItem.URL),
             })
             .ToList();
     }
@@ -193,6 +201,26 @@ public partial class Index(
 
         _rejectedFiles.Add(new RejectedFile(file, FileRejectionReason.UploadError));
         return false;
+    }
+
+    private static readonly Dictionary<string, string> _extensionToContentType = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { ".jpg",  "image/jpeg" },
+        { ".jpeg", "image/jpeg" },
+        { ".png",  "image/png" },
+        { ".gif",  "image/gif" },
+        { ".mp4",  "video/mp4" },
+        { ".webm", "video/webm" },
+        { ".ogg",  "video/ogg" },
+        { ".pdf",  "application/pdf" },
+    };
+
+    private static string GetContentTypeFromUrl(string url)
+    {
+        var extension = Path.GetExtension(new Uri(url).LocalPath);
+        return _extensionToContentType.TryGetValue(extension, out var contentType)
+            ? contentType
+            : string.Empty;
     }
 
     private async Task DeleteUploadedFile(Models.FloodReport.Create.MediaItem file)

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
@@ -74,6 +74,9 @@ public partial class Index(
     private readonly List<RejectedFile> _rejectedFiles = [];
     private string? _uploadLimitError;
 
+    private Models.FloodReport.Create.MediaItem? _renamingFile;
+    private string _renameText = string.Empty;
+
     private Models.FloodReport.Create.Media Model { get; set; } = default!;
 
     protected override void OnInitialized()
@@ -221,6 +224,46 @@ public partial class Index(
         return _extensionToContentType.TryGetValue(extension, out var contentType)
             ? contentType
             : string.Empty;
+    }
+
+    private void StartRename(Models.FloodReport.Create.MediaItem file)
+    {
+        _renamingFile = file;
+        _renameText = file.Name;
+    }
+
+    private void CancelRename()
+    {
+        _renamingFile = null;
+        _renameText = string.Empty;
+    }
+
+    private async Task SaveRename(Models.FloodReport.Create.MediaItem file)
+    {
+        if (string.IsNullOrWhiteSpace(_renameText))
+        {
+            return;
+        }
+
+        if (file.Id.HasValue)
+        {
+            var result = await mediaItemRepository.UpdateTitle(file.Id.Value, _renameText, _cts.Token);
+            if (!result.IsSuccess)
+            {
+                foreach (var error in result.Errors)
+                {
+                    logger.LogWarning("Couldn't rename media item: {ErrorMessage}", error);
+                }
+
+                _validationMessageStore.Add(_fieldIdentifier, "Sorry, something went wrong");
+                _editContext.NotifyValidationStateChanged();
+                return;
+            }
+        }
+
+        file.Name = _renameText;
+        _renamingFile = null;
+        _renameText = string.Empty;
     }
 
     private async Task DeleteUploadedFile(Models.FloodReport.Create.MediaItem file)

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
@@ -76,6 +76,7 @@ public partial class Index(
 
     private Models.FloodReport.Create.MediaItem? _renamingFile;
     private string _renameText = string.Empty;
+    private string? _renameError;
 
     private Models.FloodReport.Create.Media Model { get; set; } = default!;
 
@@ -230,18 +231,31 @@ public partial class Index(
     {
         _renamingFile = file;
         _renameText = file.Name;
+        _renameError = null;
     }
 
     private void CancelRename()
     {
         _renamingFile = null;
         _renameText = string.Empty;
+        _renameError = null;
     }
+
+    private const int MaxRenameTitleLength = 255;
 
     private async Task SaveRename(Models.FloodReport.Create.MediaItem file)
     {
+        _renameError = null;
+
         if (string.IsNullOrWhiteSpace(_renameText))
         {
+            _renameError = "Enter a file name";
+            return;
+        }
+
+        if (_renameText.Length > MaxRenameTitleLength)
+        {
+            _renameError = $"File name must be {MaxRenameTitleLength} characters or fewer";
             return;
         }
 

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
@@ -191,7 +191,7 @@ public partial class Index(
             {
                 Model.UploadedFiles.Add(new Models.FloodReport.Create.MediaItem
                 {
-                    Name = file.Name,
+                    Name = Path.GetFileNameWithoutExtension(file.Name),
                     Url = blobUrl,
                     ContentType = file.ContentType,
                 });

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.cs
@@ -269,8 +269,7 @@ public partial class Index(
                     logger.LogWarning("Couldn't rename media item: {ErrorMessage}", error);
                 }
 
-                _validationMessageStore.Add(_fieldIdentifier, "Sorry, something went wrong");
-                _editContext.NotifyValidationStateChanged();
+                _renameError = "Sorry, something went wrong";
                 return;
             }
         }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.css
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.css
@@ -3,3 +3,17 @@
     max-width: 150px;
     max-height: 100px;
 }
+
+.media-placeholder {
+    background-color: lightgrey;
+    width: 150px;
+    height: 100px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.media-placeholder__icon {
+    display: block;
+    width:40px;
+}

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.css
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Media/Index.razor.css
@@ -1,0 +1,5 @@
+/* CSS for Media/Index component */
+.media-image-preview {
+    max-width: 150px;
+    max-height: 100px;
+}

--- a/FloodOnlineReportingTool.Public/Options/AzureBlobStorageOptions.cs
+++ b/FloodOnlineReportingTool.Public/Options/AzureBlobStorageOptions.cs
@@ -5,4 +5,5 @@ public class AzureBlobStorageOptions
     public const string SectionName = "AzureBlobStorage";
     public required string ConnectionString { get; init; }
     public required string ContainerName { get; init; }
+    public string ReadSASToken { get; init; } = "";
 } 

--- a/FloodOnlineReportingTool.Public/Scripts/app.scss
+++ b/FloodOnlineReportingTool.Public/Scripts/app.scss
@@ -64,3 +64,14 @@ body {
         }
     }
 }
+
+// Links
+/* special style for buttons rendered like links */
+button.govuk-link {
+    background: none;
+    border: none;
+    font-size: inherit;
+    color: var(--govuk-frontend-color-blue);
+    padding: 0;
+    cursor: pointer;
+}

--- a/FloodOnlineReportingTool.Public/Scripts/app.scss
+++ b/FloodOnlineReportingTool.Public/Scripts/app.scss
@@ -11,7 +11,14 @@ body {
 // Fill the space when the parent is flex
 .flex-fill {
     flex: 1;
-    width: 100%;
+    min-width: 0;
+    // Below 1020px, .govuk-width-container uses fixed margins and align-self: stretch
+    // correctly sizes the element (content box = viewport - margins). Above 1020px,
+    // auto margins disable stretch, so we force an explicit width so that max-width
+    // and margin: auto can centre the 960px container as intended.
+    @media (min-width: 1020px) {
+        width: 100%;
+    }
 }
 
 // Header

--- a/FloodOnlineReportingTool.Public/Scripts/images/ban.svg
+++ b/FloodOnlineReportingTool.Public/Scripts/images/ban.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-ban" viewBox="0 0 16 16">
+  <path d="M15 8a6.97 6.97 0 0 0-1.71-4.584l-9.874 9.875A7 7 0 0 0 15 8M2.71 12.584l9.874-9.875a7 7 0 0 0-9.874 9.874ZM16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0"/>
+</svg>

--- a/FloodOnlineReportingTool.Public/Scripts/images/file-preview.svg
+++ b/FloodOnlineReportingTool.Public/Scripts/images/file-preview.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-file-earmark-text" viewBox="0 0 16 16">
+  <path d="M5.5 7a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1zM5 9.5a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1h-5a.5.5 0 0 1-.5-.5m0 2a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 0 1h-2a.5.5 0 0 1-.5-.5"/>
+  <path d="M9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.5zm0 1v2A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1z"/>
+</svg>

--- a/FloodOnlineReportingTool.Public/Scripts/images/video-preview.svg
+++ b/FloodOnlineReportingTool.Public/Scripts/images/video-preview.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-camera-video" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M0 5a2 2 0 0 1 2-2h7.5a2 2 0 0 1 1.983 1.738l3.11-1.382A1 1 0 0 1 16 4.269v7.462a1 1 0 0 1-1.406.913l-3.111-1.382A2 2 0 0 1 9.5 13H2a2 2 0 0 1-2-2zm11.5 5.175 3.5 1.556V4.269l-3.5 1.556zM2 4a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1z"/>
+</svg>

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -93,7 +93,13 @@ You must set up user secrets for development. Run the following command in the t
 Then add your configuration:
 
 - **ConnectionStrings**: Required for database access and optional message system.
-- **GIS**: Used to configure the Dorset Council Address API (customizable).
+- **AzureBlobStorage**: Required for file storage.
+  - The `ReadSASToken` is optional and can be used to provide read-only access to the blob storage.
+- **GIS**: Used to configure the Address API and other mapping related services.
+- **GovNotify**: Used to configure the GovNotify service for sending notifications.
+- **Messaging**: Used to configure the messaging system.
+- **DownstreamApis**: Used to configure downstream APIs.
+- **AzureAd**: Used to configure Azure Active Directory for authentication.
 
 Example secrets file:
 ```json
@@ -102,6 +108,11 @@ Example secrets file:
     "FloodReportingPublic": "Host=localhost;Port=5432;Database=YourDatabaseName;Username=YourUserName;Password=YourPassword;Search Path=fortpublic",
     "service-bus": "Endpoint=YourEndpoint;SharedAccessKeyName=YourKeyName;SharedAccessKey=YourAccessKey"
   },
+  "AzureBlobStorage": {
+    "ConnectionString": "DefaultEndpointsProtocol=https;AccountName=YourAccountName;AccountKey=YourAccountKey;EndpointSuffix=core.windows.net",
+    "ContainerName": "YourContainerName",
+    "ReadSASToken": "YourReadSASToken"
+  },
   "GIS": {
     "ApiKey": "YourApiKey",
     "AddressSearchUrl": "YourAddressUrl",
@@ -109,7 +120,42 @@ Example secrets file:
     "AccessTokenIssueDurationMonths": 6,
     "OSApiKey": "Your OS Maps API Key here",
     "DataRetentionYears": 7
-  }
+  },
+  "GovNotify": {
+    "ApiKey": "YourGovNotifyAPIKey",
+    "TestEmail": "test@example.com",
+    "Templates": {
+      "TestNotification": "TemplateID",
+      "VerifyEmailAddress": "TemplateID",
+      "ConfirmContactUpdated": "TemplateID",
+      "ConfirmContactDeleted": "TemplateID",
+      "RequestDpaUpdate": "TemplateID",
+      "Unsubscribe": "TemplateID",
+      "RequestFullReport": "TemplateID",
+      "SendStatusUpdate": "TemplateID",
+      "SendPublicComment": "TemplateID",
+      "SendCopyOfReport": "TemplateID",
+      "RecordDeletion": "TemplateID"
+    }
+  },
+  "Messaging": {
+    "Enabled": "true",
+    "ConnectionString": "YourServiceBusConnectionString"
+  },
+  "DownstreamApis": {
+    "ReportStatusApi": {
+      "BaseUrl": "YourReportStatusApiBaseUrl",
+      "Scopes": "ScopesRequired"
+    }
+  },
+  "AzureAd": {
+    "ClientId": "YourEntraClientID",
+    "ClientSecret": "YourEntraClientSecret",
+    "Domain": "YourEntraDomain",
+    "Instance": "https://YourEntraInstance/",
+    "ResponseType": "code",
+    "TenantId": "YourEntraTenantID"
+  },
 }
 ```
 
@@ -122,9 +168,9 @@ Authentication is not required to create a flood report. However, certain areas 
 
 The project integrates with the Dorset Council Address API. This is customizable via the `GIS` section in your configuration.
 
-For messaging, the connection string `service-bus` allows you to enable or disable the messaging system.
+For messaging, the connection string in the `Messaging` section allows you to enable or disable the messaging system.
 
-If you want to disable messaging, remove the `service-bus` connection string from your configuration.
+If you want to disable messaging, set `"Enabled": "false"` in your `Messaging` configuration.
 
 ## Further Help
 


### PR DESCRIPTION
# Summary

This PR improves the user experience of the media upload, allowing users to

- See a small preview of any images they upload. Non images are shown as a basic placeholder
- Rename any files they have uploaded
- View files they have uploaded in a new window

## Setting changes

A new setting is required within the `AzureBlobStorageOptions` called `ReadSASToken`. This should be filled with a read-only valid SAS token for accessing the Blob container, to allow for secure retrieval of media from the store. 

# Other changes
A minor fix was added to the `flex-fill` class to prevent odd resizing behaviour at mobile sized viewports.

# Limitations and future improvements
- Error handling of file renames is not integrated with the full fluent validation suite, since it does not sit in a proper edit context and it could cause confusion and issues with the existing validation on the page. For the sake of simplicity, the error handling for this field is managed manually.
- The images are pulled down at full size, and then rescaled to a very small size. This is inefficient. A better solution would be to generate thumbnails on upload, and only pull down the thumbnails for the preview. This however required more work than was deemed necessary for this issue, so will covered in a separate issue.

Closes #196 