### PR TITLE
Update Flood Report Source to have a 15 character Reference field.

### DIFF
--- a/Database/EntitiesConfiguration/FloodReportSourceConfiguration.cs
+++ b/Database/EntitiesConfiguration/FloodReportSourceConfiguration.cs
@@ -12,21 +12,17 @@ internal class FloodReportSourceConfiguration : IEntityTypeConfiguration<FloodRe
         builder
             .ToTable(o => o.HasComment("Flood report sources"));
 
+        builder.HasKey(o => o.Id);
+        // Unique constraint ensures Reference is consistent across FORT modules
+        builder.HasAlternateKey(o => o.Reference);
+
         builder
             .Property(o => o.Id)
             .ValueGeneratedNever();
 
         builder
-            .HasIndex(o => o.Id)
-            .IsUnique();
-
-        builder
-            .HasIndex(o => o.Reference)
-            .IsUnique();
-
-        builder
             .Property(o => o.Reference)
-            .HasMaxLength(8);
+            .HasMaxLength(15);
 
         builder
             .Property(o => o.StatusId)

--- a/Database/Migrations/20260709154219_IncreaseRefSize.Designer.cs
+++ b/Database/Migrations/20260709154219_IncreaseRefSize.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FloodOnlineReportingTool.Database.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FloodOnlineReportingTool.Database.Migrations
 {
     [DbContext(typeof(PublicDbContext))]
-    partial class PublicDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709154219_IncreaseRefSize")]
+    partial class IncreaseRefSize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20260709154219_IncreaseRefSize.cs
+++ b/Database/Migrations/20260709154219_IncreaseRefSize.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FloodOnlineReportingTool.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncreaseRefSize : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_FloodReportSources_Id",
+                schema: "fortpublic",
+                table: "FloodReportSources");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FloodReportSources_Reference",
+                schema: "fortpublic",
+                table: "FloodReportSources");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Reference",
+                schema: "fortpublic",
+                table: "FloodReportSources",
+                type: "character varying(15)",
+                maxLength: 15,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(8)",
+                oldMaxLength: 8);
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_FloodReportSources_Reference",
+                schema: "fortpublic",
+                table: "FloodReportSources",
+                column: "Reference");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_FloodReportSources_Reference",
+                schema: "fortpublic",
+                table: "FloodReportSources");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Reference",
+                schema: "fortpublic",
+                table: "FloodReportSources",
+                type: "character varying(8)",
+                maxLength: 8,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(15)",
+                oldMaxLength: 15);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FloodReportSources_Id",
+                schema: "fortpublic",
+                table: "FloodReportSources",
+                column: "Id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FloodReportSources_Reference",
+                schema: "fortpublic",
+                table: "FloodReportSources",
+                column: "Reference",
+                unique: true);
+        }
+    }
+}


### PR DESCRIPTION
Update Flood Report Source to have a 15 character Reference field.
Use HasKey and HasAlternateKey to be consistent with recent changes to the report status module.