### PR TITLE
Convert centimetres into a string with different measurement formats

### DIFF
--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/PeakDepth.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/PeakDepth.razor
@@ -49,18 +49,18 @@
                                                         <GdsInputText @bind-Value="Model.InsideCentimetresText" class="govuk-input govuk-input--width-3" spellcheck="false" inputmode="numeric" />
                                                         <div class="govuk-input__suffix" aria-hidden="true">cm</div>
                                                     </div>
-                                                </GdsFormGroup>
-                                                
-                                                <GdsHint Id="inside-total">
-                                                    @if(Model.InsideCentimetres.HasValue && Model.InsideCentimetres.Value >=0)
+                                                    
+                                                    @if(Model.InsideCentimetres.HasValue)
                                                     {
+                                                        <GdsHint Id="inside-total" CssClass="govuk-hint govuk-!-margin-bottom-0">
                                                         <span>This is roughly equal to @Model.InsideFeetAndInches</span>
+                                                    </GdsHint>
                                                     }
-                                                </GdsHint>
+                                                </GdsFormGroup>
                                             </div>
 
                                             <div>
-                                                <GdsFormGroup For="() => Model.OutsideCentimetresText">
+                                                <GdsFormGroup For="() => Model.OutsideCentimetresText" AdditionalCssClasses="govuk-!-margin-top-3">
                                                     <GdsLabel Text="What was the depth outside?" />
                                                     <GdsHint>Total centimetres, like 5</GdsHint>
                                                     <GdsErrorMessage />
@@ -68,14 +68,17 @@
                                                         <GdsInputText @bind-Value="Model.OutsideCentimetresText" class="govuk-input govuk-input--width-3" spellcheck="false" inputmode="numeric" />
                                                         <div class="govuk-input__suffix" aria-hidden="true">cm</div>
                                                     </div>
+                                                    
+                                                    @if(Model.OutsideCentimetres.HasValue)
+                                                    {
+                                                        <GdsHint Id="outside-total">
+                                                            <span>This is roughly equal to @Model.OutsideFeetAndInches</span>
+                                                        </GdsHint>
+                                                    }
+                                                    
                                                 </GdsFormGroup>
                                                 
-                                                <GdsHint Id="outside-total">
-                                                    @if(Model.OutsideCentimetres.HasValue && Model.OutsideCentimetres.Value >=0)
-                                                    {
-                                                        <span>This is roughly equal to @Model.OutsideFeetAndInches</span>
-                                                    }
-                                                </GdsHint>
+                                                
                                             </div>
                                         </div>
                                     }

--- a/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/PeakDepth.razor
+++ b/FloodOnlineReportingTool.Public/Components/Pages/FloodReport/Investigation/PeakDepth.razor
@@ -50,8 +50,13 @@
                                                         <div class="govuk-input__suffix" aria-hidden="true">cm</div>
                                                     </div>
                                                 </GdsFormGroup>
-
-                                                <GdsHint Id="inside-total">This it roughly equal to @Model.InsideFeet feet and @Model.InsideInches inches</GdsHint>
+                                                
+                                                <GdsHint Id="inside-total">
+                                                    @if(Model.InsideCentimetres.HasValue && Model.InsideCentimetres.Value >=0)
+                                                    {
+                                                        <span>This is roughly equal to @Model.InsideFeetAndInches</span>
+                                                    }
+                                                </GdsHint>
                                             </div>
 
                                             <div>
@@ -64,8 +69,13 @@
                                                         <div class="govuk-input__suffix" aria-hidden="true">cm</div>
                                                     </div>
                                                 </GdsFormGroup>
-
-                                                <GdsHint Id="outside-total">This it roughly equal to @Model.OutsideFeet feet and @Model.OutsideInches inches</GdsHint>
+                                                
+                                                <GdsHint Id="outside-total">
+                                                    @if(Model.OutsideCentimetres.HasValue && Model.OutsideCentimetres.Value >=0)
+                                                    {
+                                                        <span>This is roughly equal to @Model.OutsideFeetAndInches</span>
+                                                    }
+                                                </GdsHint>
                                             </div>
                                         </div>
                                     }

--- a/FloodOnlineReportingTool.Public/Extensions/StringExtensions.cs
+++ b/FloodOnlineReportingTool.Public/Extensions/StringExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace System;
+﻿using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Tests")]
+
+namespace System;
 
 internal static class StringExtensions
 {
@@ -20,5 +23,76 @@ internal static class StringExtensions
             2 => $"{itemArray[0]}{finalSeparator}{itemArray[1]}",
             _ => $"{string.Join(separator, itemArray[..^1])}{finalSeparator}{itemArray[^1]}",
         };
+    }
+
+
+    public enum MeasurementDisplayType
+    {
+        Centimetres,
+        MetresAndCentimetres,
+        Inches,
+        FeetAndInches
+    }
+
+    /// <summary>
+    /// Converts a measurement in centimetres to a display string in the specified format.
+    /// </summary>
+    /// <param name="measurementInCentimetres">The measurement in centimetres to convert.</param>
+    /// <param name="displayType">The format in which to display the measurement.</param>
+    /// <returns>A string representing the measurement in the specified format.</returns>
+    /// <example>When using MeasurementDisplayType.FeetAndInches, a value of 63 centimetres would be returned as "2 feet 1 inch".</example>
+    internal static string ConvertMeasurementToDisplayString(this int? measurementInCentimetres, MeasurementDisplayType displayType)
+    {
+        if (measurementInCentimetres is null)
+        {
+            return string.Empty;
+        }
+        if (measurementInCentimetres < 0)
+        {
+            return "cannot convert negative number";
+        }
+
+        int measurementInInches = Convert.ToInt32(measurementInCentimetres.Value / 2.54);
+
+        return displayType switch
+        { 
+            MeasurementDisplayType.Centimetres => 
+                measurementInCentimetres switch
+                {
+                    1 => "1 centimetre",
+                    _ => $"{measurementInCentimetres} centimetres"
+                },
+            MeasurementDisplayType.MetresAndCentimetres =>
+                measurementInCentimetres switch
+                {
+                    1 => "1 centimetre",
+                    < 100 => $"{measurementInCentimetres} centimetres",
+                    100 => $"1 metre",
+                    101 => $"1 metre 1 centimetre",
+                    < 200 => $"1 metre {measurementInCentimetres - 100} centimetres",
+                    _ when measurementInCentimetres % 100 == 0 => $"{measurementInCentimetres / 100} metres",
+                    _ when measurementInCentimetres % 100 == 1 => $"{measurementInCentimetres / 100} metres 1 centimetre",
+                    _ => $"{measurementInCentimetres / 100} metres {measurementInCentimetres % 100} centimetres"
+                },
+            MeasurementDisplayType.Inches =>
+                measurementInInches switch
+                {
+                    1 => "1 inch",
+                    _ => $"{measurementInInches} inches"
+                },
+            MeasurementDisplayType.FeetAndInches => 
+                measurementInInches switch
+                {
+                    1 => "1 inch",
+                    < 12 => $"{measurementInInches} inches",
+                    12 => $"1 foot",
+                    13 => $"1 foot 1 inch",
+                    < 24 => $"1 foot {measurementInInches - 12} inches",
+                    _ when measurementInInches % 12 == 0 => $"{measurementInInches / 12} feet",
+                    _ when measurementInInches % 12 == 1 => $"{measurementInInches / 12} feet 1 inch",
+                    _ => $"{measurementInInches / 12} feet {measurementInInches % 12} inches"
+                },
+            _ => string.Empty
+        };   
     }
 }

--- a/FloodOnlineReportingTool.Public/Extensions/StringExtensions.cs
+++ b/FloodOnlineReportingTool.Public/Extensions/StringExtensions.cs
@@ -26,7 +26,7 @@ internal static class StringExtensions
     }
 
 
-    public enum MeasurementDisplayType
+    internal enum MeasurementDisplayType
     {
         Centimetres,
         MetresAndCentimetres,

--- a/FloodOnlineReportingTool.Public/Models/FloodReport/Investigation/PeakDepth.cs
+++ b/FloodOnlineReportingTool.Public/Models/FloodReport/Investigation/PeakDepth.cs
@@ -12,15 +12,13 @@ public class PeakDepth
     public string? InsideCentimetresText { get; set; }
     public float? InsideCentimetresNumber => ToFloat(InsideCentimetresText);
     public int? InsideCentimetres => WholeNumberInt(InsideCentimetresNumber);
-    public int InsideFeet => InsideCentimetres.HasValue ? Convert.ToInt32(Math.Floor(InsideCentimetres.Value / 30.48)) : 0;
-    public int InsideInches => InsideCentimetres.HasValue ? Convert.ToInt32(Math.Floor(InsideCentimetres.Value / 2.54)) : 0;
+    public string InsideFeetAndInches => InsideCentimetres.ConvertMeasurementToDisplayString(StringExtensions.MeasurementDisplayType.FeetAndInches);
 
     [GdsFieldErrorClass(GdsFieldTypes.Input)]
     public string? OutsideCentimetresText { get; set; }
     public float? OutsideCentimetresNumber => ToFloat(OutsideCentimetresText);
     public int? OutsideCentimetres => WholeNumberInt(OutsideCentimetresNumber);
-    public int OutsideFeet => OutsideCentimetres.HasValue ? Convert.ToInt32(Math.Floor(OutsideCentimetres.Value / 30.48)) : 0;
-    public int OutsideInches => OutsideCentimetres.HasValue ? Convert.ToInt32(Math.Floor(OutsideCentimetres.Value / 2.54)) : 0;
+    public string OutsideFeetAndInches => OutsideCentimetres.ConvertMeasurementToDisplayString(StringExtensions.MeasurementDisplayType.FeetAndInches);
 
     private static float? ToFloat(string? value)
     {

--- a/FloodOnlineReportingTool.Public/Validators/Investigation/PeakDepthValidator.cs
+++ b/FloodOnlineReportingTool.Public/Validators/Investigation/PeakDepthValidator.cs
@@ -24,6 +24,8 @@ public class PeakDepthValidator : AbstractValidator<PeakDepth>
                 RuleFor(o => o.InsideCentimetresNumber)
                     .NotEmpty()
                     .WithMessage("Depth inside must be a number")
+                    .GreaterThanOrEqualTo(0)
+                    .WithMessage("Depth must be a positive number")
                     .OverridePropertyName(o => o.InsideCentimetresText);
 
                 RuleFor(o => o.InsideCentimetres)
@@ -44,6 +46,8 @@ public class PeakDepthValidator : AbstractValidator<PeakDepth>
                 RuleFor(o => o.OutsideCentimetresNumber)
                 .NotEmpty()
                 .WithMessage("Depth outside must be a number")
+                .GreaterThanOrEqualTo(0)
+                .WithMessage("Depth must be a positive number")
                 .OverridePropertyName(o => o.OutsideCentimetresText);
 
                 RuleFor(o => o.OutsideCentimetres)

--- a/Tests/Extensions/StringExtensionsTests.cs
+++ b/Tests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,62 @@
+﻿using FloodOnlineReportingTool.Contracts.Topics;
+using Messaging.Consumers;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tests.Extensions;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineData(null, StringExtensions.MeasurementDisplayType.Centimetres, "")]
+    [InlineData(-1, StringExtensions.MeasurementDisplayType.Centimetres, "cannot convert negative number")]
+    [InlineData(0, StringExtensions.MeasurementDisplayType.Centimetres, "0 centimetres")]
+    [InlineData(1, StringExtensions.MeasurementDisplayType.Centimetres, "1 centimetre")]
+    [InlineData(2, StringExtensions.MeasurementDisplayType.Centimetres, "2 centimetres")]
+    [InlineData(999, StringExtensions.MeasurementDisplayType.Centimetres, "999 centimetres")]
+    [InlineData(null, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "")]
+    [InlineData(-1, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "cannot convert negative number")]
+    [InlineData(0, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "0 centimetres")]
+    [InlineData(1, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "1 centimetre")]
+    [InlineData(2, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "2 centimetres")]
+    [InlineData(99, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "99 centimetres")]
+    [InlineData(100, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "1 metre")]
+    [InlineData(101, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "1 metre 1 centimetre")]
+    [InlineData(199, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "1 metre 99 centimetres")]
+    [InlineData(200, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "2 metres")]
+    [InlineData(201, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "2 metres 1 centimetre")]
+    [InlineData(299, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "2 metres 99 centimetres")]
+    [InlineData(999, StringExtensions.MeasurementDisplayType.MetresAndCentimetres, "9 metres 99 centimetres")]
+    [InlineData(null, StringExtensions.MeasurementDisplayType.Inches, "")]
+    [InlineData(-1, StringExtensions.MeasurementDisplayType.Inches, "cannot convert negative number")]
+    [InlineData(0, StringExtensions.MeasurementDisplayType.Inches, "0 inches")]
+    [InlineData(1, StringExtensions.MeasurementDisplayType.Inches, "0 inches")]
+    [InlineData(2, StringExtensions.MeasurementDisplayType.Inches, "1 inch")]
+    [InlineData(3, StringExtensions.MeasurementDisplayType.Inches, "1 inch")]
+    [InlineData(5, StringExtensions.MeasurementDisplayType.Inches, "2 inches")]
+    [InlineData(999, StringExtensions.MeasurementDisplayType.Inches, "393 inches")]
+    [InlineData(null, StringExtensions.MeasurementDisplayType.FeetAndInches, "")]
+    [InlineData(-1, StringExtensions.MeasurementDisplayType.FeetAndInches, "cannot convert negative number")]
+    [InlineData(0, StringExtensions.MeasurementDisplayType.FeetAndInches, "0 inches")]
+    [InlineData(1, StringExtensions.MeasurementDisplayType.FeetAndInches, "0 inches")]
+    [InlineData(2, StringExtensions.MeasurementDisplayType.FeetAndInches, "1 inch")]
+    [InlineData(3, StringExtensions.MeasurementDisplayType.FeetAndInches, "1 inch")]
+    [InlineData(5, StringExtensions.MeasurementDisplayType.FeetAndInches, "2 inches")]
+    [InlineData(31, StringExtensions.MeasurementDisplayType.FeetAndInches, "1 foot")]
+    [InlineData(33, StringExtensions.MeasurementDisplayType.FeetAndInches, "1 foot 1 inch")]
+    [InlineData(58, StringExtensions.MeasurementDisplayType.FeetAndInches, "1 foot 11 inches")]
+    [InlineData(61, StringExtensions.MeasurementDisplayType.FeetAndInches, "2 feet")]
+    [InlineData(63, StringExtensions.MeasurementDisplayType.FeetAndInches, "2 feet 1 inch")]
+    [InlineData(89, StringExtensions.MeasurementDisplayType.FeetAndInches, "2 feet 11 inches")]
+    [InlineData(999, StringExtensions.MeasurementDisplayType.FeetAndInches, "32 feet 9 inches")]
+    internal Task TopicName_Returns_ExpectedTopicName_ForConfiguredSuffix(int? cm, StringExtensions.MeasurementDisplayType mdt, string expectedResult)
+    {
+        var actualResult = cm.ConvertMeasurementToDisplayString(mdt);
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+        return Task.CompletedTask;
+    }
+}

--- a/Tests/Extensions/StringExtensionsTests.cs
+++ b/Tests/Extensions/StringExtensionsTests.cs
@@ -51,7 +51,7 @@ public class StringExtensionsTests
     [InlineData(63, StringExtensions.MeasurementDisplayType.FeetAndInches, "2 feet 1 inch")]
     [InlineData(89, StringExtensions.MeasurementDisplayType.FeetAndInches, "2 feet 11 inches")]
     [InlineData(999, StringExtensions.MeasurementDisplayType.FeetAndInches, "32 feet 9 inches")]
-    internal Task TopicName_Returns_ExpectedTopicName_ForConfiguredSuffix(int? cm, StringExtensions.MeasurementDisplayType mdt, string expectedResult)
+    internal Task ConvertMeasurementToDisplayString_ReturnsExpectedString_ForAllScenarios(int? cm, StringExtensions.MeasurementDisplayType mdt, string expectedResult)
     {
         var actualResult = cm.ConvertMeasurementToDisplayString(mdt);
 


### PR DESCRIPTION
Created and used code to convert centimetres into a string with different measurement formats. As an example, when using MeasurementDisplayType.FeetAndInches, a value of 63 centimetres would be returned as "2 feet 1 inch". This fixes a bug whereby the above would be displayed as "2 foot 25 inches" on the flood depth page.
I don't know whether the plural of 'feet' is prefered here - if not I can change it.
I have also added using System.Runtime.CompilerServices; [assembly: InternalsVisibleTo("Tests")] to StringExtensions to allow unit testing. If there is a better way of doing this, I can just make the class public or I should move it to a different class then I can change this. If there is a better place for the MeasurementDisplayType enum I can also move that.